### PR TITLE
make replace config global, simplify temp macro override for schema with location property

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -42,3 +42,4 @@ models:
     +materialized: view       # fallback default, materialized should be overriden in model specific configs
     +schema: no_schema        # fallback default, schema should be overriden in model specific configs
     +view_security: invoker   # required security setting for views
+    +on_table_exists: replace # dunesql hive metastore does *not* allow rename of table, meaning standard dbt table operations won't work (drop temp table, create temp table, rename existing table to backup, rename temp to final, drop backup)

--- a/macros/dune_dbt_overrides/schema.sql
+++ b/macros/dune_dbt_overrides/schema.sql
@@ -1,20 +1,11 @@
 {#
-    goal: remove this macro override, have the backend handle s3 bucket names
+    TODO: remove this macro override, have the backend handle s3 bucket names
       - prod: trino-prod-datasets-118330671040/write/<customer_team_name>/…
       - dev:  trino-dev-datasets-118330671040/write/<customer_team_name>/…
-    goal: remove the trino__create_schema macro override and ensure backend applies <WITH location> logic
 #}
-
-{%- macro s3_bucket() -%}
-  {%- if target.name == 'prod' -%}
-    {{- return('prod-spellbook-trino-118330671040') -}}
-  {%- else -%}
-    {{- return('trino-dev-datasets-118330671040') -}}
-  {%- endif -%}
-{%- endmacro -%}
 
 {% macro trino__create_schema(relation) -%}
   {%- call statement('create_schema') -%}
-   CREATE SCHEMA {{ relation }} WITH (location = 's3a://{{s3_bucket()}}/')
+   CREATE SCHEMA {{ relation }} WITH (location = 's3a://prod-spellbook-trino-118330671040/{{relation}}/')
   {% endcall %}
 {% endmacro %}

--- a/models/dbt_template_incremental_model.sql
+++ b/models/dbt_template_incremental_model.sql
@@ -11,7 +11,6 @@
     , incremental_strategy = 'merge'
     , unique_key = ['block_number', 'block_date']
     , incremental_predicates = ["DBT_INTERNAL_DEST.block_date >= now() - interval '1' day"]
-    , on_table_exists = 'replace'
 )
 }}
 

--- a/models/dbt_template_table_model.sql
+++ b/models/dbt_template_table_model.sql
@@ -1,7 +1,5 @@
 {#
     key notes on table model:
-    - on_table_exists = 'replace' is used to replace the table if it already exists
-        - dunesql hive metastore does *not* allow rename of table, meaning standard dbt table operations won't work (drop temp table, create temp table, rename existing table to backup, rename temp to final, drop backup)
     - file_format defaults to delta (TODO: confirm this is dune hive metastore setting)
         - when providing file_format config to model, dbt fails on unable to support 'format' property
 #}

--- a/models/dbt_template_table_model.sql
+++ b/models/dbt_template_table_model.sql
@@ -10,7 +10,6 @@
     schema = 'test_schema'
     , alias = 'dbt_template_table_model'
     , materialized = 'table'
-    , on_table_exists = 'replace'
 )
 }}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Make table replace behavior global and simplify schema creation by inlining a fixed S3 location, removing per-model replace configs and the s3_bucket macro.
> 
> - **Config**:
>   - Add `+on_table_exists: replace` to `models: dbt_template` in `dbt_project.yml`.
> - **Macros**:
>   - Remove `s3_bucket()` and update `trino__create_schema` to use `s3a://prod-spellbook-trino-118330671040/{{relation}}/` in `macros/dune_dbt_overrides/schema.sql`.
> - **Models**:
>   - Remove `on_table_exists = 'replace'` from `models/dbt_template_table_model.sql` and `models/dbt_template_incremental_model.sql`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 112d2aaa9fafdbab473a0f42fd343e5ff8d24e89. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->