### PR TITLE
fix compile warnings, use old profile for now

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -6,8 +6,8 @@ name: 'dbt_template'
 version: '1.0.0'
 
 # This setting configures which "profile" dbt uses for this project.
-# profile: 'dbt_template' # legacy connection profile, direct access
-profile: 'dbt_template_api' # new connection profile, dune connectivity / api
+profile: 'dbt_template' # legacy connection profile, direct access
+# profile: 'dbt_template_api' # new connection profile, dune connectivity / api
 
 # SSL certificate validation is disabled by default. It is legacy behavior which will be changed in future releases.
 # It is strongly advised to enable `require_certificate_validation` flag or explicitly set `cert` configuration to `True` for security reasons.

--- a/models/_schema.yml
+++ b/models/_schema.yml
@@ -23,9 +23,10 @@ models:
     description: "A starter dbt incremental model"
     data_tests:
       - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - block_number
-            - block_date
+          arguments:
+            combination_of_columns:
+              - block_number
+              - block_date
     columns:
       - name: block_number
         description: "The unique block number in last 1 day"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Reverts `dbt_project.yml` to use legacy profile and updates `dbt_utils.unique_combination_of_columns` to use `arguments` in `models/_schema.yml`.
> 
> - **Config**:
>   - Switch `profile` in `dbt_project.yml` to `dbt_template` (legacy) and comment out `dbt_template_api`.
> - **Models/Test**:
>   - Update `dbt_utils.unique_combination_of_columns` in `models/_schema.yml` to use `arguments` with `combination_of_columns`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 441038db60a0f40eeb3b1fcc7ce493882e0c667e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->