### PR TITLE
cleanup schema naming standards

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -28,3 +28,6 @@ export DBT_TEMPLATE_API_KEY=your_dune_api_key_here # unique API key from your ow
 export DBT_TEMPLATE_HOST=dune-api-trino.dune.com
 export DBT_TEMPLATE_CATALOG=delta_prod
 export DBT_TEMPLATE_SCHEMA=your_dune_team_name
+
+# DEV_SCHEMA_SUFFIX is used to add a suffix to the schema name for dev/CI deployments
+export DEV_SCHEMA_SUFFIX=your_name_or_project_here # this value can be anything, it's meant to be a suffix on schema names to help differentiate from prod or other developer work

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -40,6 +40,5 @@ models:
   dbt_template:
     # Config indicated by + and applies to all files under models/example/
     +materialized: view       # fallback default, materialized should be overriden in model specific configs
-    +schema: no_schema        # fallback default, schema should be overriden in model specific configs
     +view_security: invoker   # required security setting for views
     +on_table_exists: replace # dunesql hive metastore does *not* allow rename of table, meaning standard dbt table operations won't work (drop temp table, create temp table, rename existing table to backup, rename temp to final, drop backup)

--- a/macros/dune_dbt_overrides/schema.sql
+++ b/macros/dune_dbt_overrides/schema.sql
@@ -1,11 +1,11 @@
 {#
-    TODO: remove this macro override, have the backend handle s3 bucket names
+    TODO: remove this macro override, have the backend handle s3 bucket names + directory prefix structure
       - prod: trino-prod-datasets-118330671040/write/<customer_team_name>/…
       - dev:  trino-dev-datasets-118330671040/write/<customer_team_name>/…
 #}
 
 {% macro trino__create_schema(relation) -%}
   {%- call statement('create_schema') -%}
-   CREATE SCHEMA {{ relation }} WITH (location = 's3a://prod-spellbook-trino-118330671040/{{relation}}/')
+   CREATE SCHEMA {{ relation }} WITH (location = 's3a://prod-spellbook-trino-118330671040/{{relation.schema}}/')
   {% endcall %}
 {% endmacro %}

--- a/models/templates/dbt_template_incremental_model.sql
+++ b/models/templates/dbt_template_incremental_model.sql
@@ -5,8 +5,7 @@
 #}
 
 {{ config(
-    schema = 'test_schema'
-    , alias = 'dbt_template_incremental_model'
+    alias = 'dbt_template_incremental_model'
     , materialized = 'incremental'
     , incremental_strategy = 'merge'
     , unique_key = ['block_number', 'block_date']

--- a/models/templates/dbt_template_table_model.sql
+++ b/models/templates/dbt_template_table_model.sql
@@ -5,8 +5,7 @@
 #}
 
 {{ config(
-    schema = 'test_schema'
-    , alias = 'dbt_template_table_model'
+    alias = 'dbt_template_table_model'
     , materialized = 'table'
 )
 }}

--- a/models/templates/dbt_template_view_model.sql
+++ b/models/templates/dbt_template_view_model.sql
@@ -1,6 +1,5 @@
 {{ config(
-    schema = 'test_schema'
-    , alias = 'dbt_template_view_model'
+    alias = 'dbt_template_view_model'
     , materialized = 'view'
 )
 }}

--- a/profiles.yml
+++ b/profiles.yml
@@ -21,6 +21,25 @@ dbt_template_old:
       session_properties:
         query_max_run_time: 12h
       timezone: UTC
+    dev:
+      type: trino
+      user: "{{ env_var('DBT_TEMPLATE_OLD_USER') }}"
+      password: "{{ env_var('DBT_TEMPLATE_OLD_PASSWORD') }}"
+      host: "{{ env_var('DBT_TEMPLATE_OLD_HOST') }}"
+      port: 443
+      method: ldap
+      database: hive
+      schema: "{{ env_var('DBT_TEMPLATE_OLD_SCHEMA') }}"
+      threads: 4
+      http_scheme: https
+      cert: true
+      http_headers:
+        X-Trino-Routing-Group: "{{ env_var('DBT_TEMPLATE_OLD_ROUTING_GROUP') }}"
+        X-Forwarded-Proto: https
+        X-Trino-Extra-Credential: "dune={{ env_var('DBT_TEMPLATE_OLD_EXTRA_CREDENTIAL') }}"
+      session_properties:
+        query_max_run_time: 12h
+      timezone: UTC
 
 # new config, dune connectivity, api
 dbt_template:


### PR DESCRIPTION
note: at this time, i'm omitting `custom_schema_name` that can be used in model configs. this means any unique naming for a customer will need to be in the alias. i will finalize with the team if we want to allow custom schema suffixes (i.e. `blockworks__tmp_dex.trades` vs. `blockworks__tmp_.dex_trades`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches to environment-driven schema naming with optional dev suffix, updates schema creation path, removes model-level schema configs, and adds a legacy dev profile.
> 
> - **Schema naming strategy**:
>   - Overhaul `macros/dune_dbt_overrides/get_custom_schema.sql` to derive schemas from `target.schema`, with CI using `test_schema`, prod using `target.schema`, and non-prod appending `__tmp_` plus optional `DEV_SCHEMA_SUFFIX`.
> - **Model configurations**:
>   - Remove explicit `schema` from `models/templates/*` configs to rely on macro-driven schema naming.
>   - Drop project-level `+schema` default in `dbt_project.yml`.
> - **Schema creation**:
>   - Update `macros/dune_dbt_overrides/schema.sql` to use `{{ relation.schema }}` in S3 path instead of `{{ relation }}`.
> - **Profiles and env**:
>   - Add `dev` output to legacy profile in `profiles.yml`.
>   - Introduce `DEV_SCHEMA_SUFFIX` in `.envrc.example` for dev/CI schema suffixing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94da546af37879c4dc537020a7c9d16f4cc6dbc1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->