### PR TITLE
CUR2-792 extend CI workflow to run modified only

### DIFF
--- a/.github/workflows/dbt_run.yml
+++ b/.github/workflows/dbt_run.yml
@@ -24,6 +24,33 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch full history for comparison
+
+      - name: Enforce branch is up-to-date with main
+        run: |
+          git fetch origin main:main
+          BEHIND=$(git rev-list --count HEAD..main)
+          AHEAD=$(git rev-list --count main..HEAD)
+          
+          echo "📊 Branch Status:"
+          echo "  - Commits ahead of main: $AHEAD"
+          echo "  - Commits behind main: $BEHIND"
+          
+          if [ $BEHIND -gt 0 ]; then
+            echo ""
+            echo "❌ ERROR: This branch is $BEHIND commit(s) behind main"
+            echo ""
+            echo "Please update your branch with the latest changes from main:"
+            echo "  git fetch origin main"
+            echo "  git merge origin/main"
+            echo "  # or: git rebase origin/main"
+            echo ""
+            echo "This ensures your changes are tested against the latest codebase."
+            exit 1
+          fi
+          
+          echo "✅ Branch is up-to-date with main"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -36,17 +63,50 @@ jobs:
       - name: Install dbt packages
         run: uv run dbt deps
 
-      - name: Compile models
+      - name: Checkout main branch for state comparison
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          path: main-branch
+
+      - name: Install dbt packages for main branch
+        working-directory: main-branch
+        run: uv run dbt deps
+
+      - name: Generate manifest from main branch
+        working-directory: main-branch
         run: uv run dbt compile
 
-      - name: Run models (full refresh)
-        run: uv run dbt run --full-refresh
+      - name: Copy main manifest to state directory
+        run: |
+          mkdir -p state
+          cp main-branch/target/manifest.json state/manifest.json
 
-      - name: Test models (after full refresh)
-        run: uv run dbt test
+      - name: Upload main branch manifest as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: main-manifest
+          path: state/manifest.json
+          retention-days: 7
+
+      - name: Compile feature branch models
+        run: uv run dbt compile
+
+      - name: Upload feature branch manifest as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: feature-manifest
+          path: target/manifest.json
+          retention-days: 7
+
+      - name: Run modified models (full refresh)
+        run: uv run dbt run --select state:modified --state ./state --full-refresh
+
+      - name: Test modified models (after full refresh)
+        run: uv run dbt test --select state:modified --state ./state
   
-      - name: Run models (incremental)
-        run: uv run dbt run
+      - name: Run modified models (incremental)
+        run: uv run dbt run --select state:modified --state ./state
 
-      - name: Test models (after incremental)
-        run: uv run dbt test
+      - name: Test modified models (after incremental)
+        run: uv run dbt test --select state:modified --state ./state

--- a/models/templates/dbt_template_view_model.sql
+++ b/models/templates/dbt_template_view_model.sql
@@ -7,7 +7,7 @@
 select
     block_number
     , block_date
-    , count(1) as total_tx_per_block
+    , count(1) as total_tx_per_block -- this is a comment to test CI workflow
 from
     {{ source('ethereum', 'transactions') }}
 where

--- a/models/templates/dbt_template_view_model.sql
+++ b/models/templates/dbt_template_view_model.sql
@@ -7,7 +7,7 @@
 select
     block_number
     , block_date
-    , count(1) as total_tx_per_block -- this is a comment to test CI workflow
+    , count(1) as total_tx_per_block
 from
     {{ source('ethereum', 'transactions') }}
 where


### PR DESCRIPTION
summary of changes:
- first compare to main branch to ensure up to date. fail if not. the intention here is to handle for the scenario where feature branch A builds new model and PR is opened, then feature branch B builds another new model and PR is opened then merged. feature branch A on any PR CI workflow rerun would then potentially run the model from feature branch B since out of date during manifest comparison.
- checkout main branch and build manifest artifacts. save in action run history for 7 days.
- build feature branch manifest artifacts. save in action run history for 7 days.
- use built-in `state:modified` check to only run what has changed

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> GitHub Actions workflow now enforces branch is up-to-date, compares manifests with main, and runs/tests only modified dbt models; manifests are uploaded as artifacts.
> 
> - **CI Workflow (`.github/workflows/dbt_run.yml`)**:
>   - **Branch hygiene**: Fetch full history (`fetch-depth: 0`) and fail if branch is behind `main`.
>   - **State-based selection**:
>     - Check out `main`, install deps, compile, and save `main` `manifest.json` to `state/` (also upload as artifact).
>     - Compile feature branch and upload its `manifest.json` as artifact.
>     - Run `dbt run`/`dbt test` with `--select state:modified --state ./state` for both full-refresh and incremental.
>   - Removes running/testing all models unconditionally in favor of modified-only execution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c21a74683401037821afcb4d5bdc753d285e207. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->