### PR TITLE
CUR2-791 init prod gh workflow

### DIFF
--- a/.github/workflows/dbt_prod.yml
+++ b/.github/workflows/dbt_prod.yml
@@ -1,0 +1,84 @@
+name: dbt prod orchestration
+
+on:
+  schedule:
+    - cron: '0 * * * *'  # Run every hour at minute 0
+  workflow_dispatch:  # Allow manual triggers
+
+jobs:
+  dbt-prod:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    
+    env:
+      DUNE_API_KEY: ${{ secrets.DUNE_API_KEY }}
+      DUNE_TEAM_NAME: ${{ vars.DUNE_TEAM_NAME || 'dune' }}  # Set as GitHub Variable or defaults to 'dune'
+    
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --locked
+
+      - name: Install dbt packages
+        run: uv run dbt deps
+
+      - name: Download previous manifest for state comparison
+        id: download-manifest
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: prod-manifest-latest
+          path: ./state
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compile current models
+        run: uv run dbt compile
+
+      - name: Determine if previous state exists
+        id: check-state
+        run: |
+          if [ -f "./state/manifest.json" ]; then
+            echo "state_exists=true" >> $GITHUB_OUTPUT
+            echo "✅ Previous manifest found - will run modified models only"
+          else
+            echo "state_exists=false" >> $GITHUB_OUTPUT
+            echo "⚠️  No previous manifest found - will run all models (first run or artifact expired)"
+          fi
+
+      - name: Run modified models with full refresh
+        if: steps.check-state.outputs.state_exists == 'true'
+        run: uv run dbt run --select state:modified+ --state ./state --full-refresh
+
+      - name: Test modified models
+        if: steps.check-state.outputs.state_exists == 'true'
+        run: uv run dbt test --select state:modified+ --state ./state
+
+      - name: Run all models
+        run: uv run dbt run
+
+      - name: Test all models
+        run: uv run dbt test
+
+      - name: Upload current manifest for next run
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: prod-manifest-latest
+          path: target/manifest.json
+          retention-days: 90
+          overwrite: true # overwrite the artifact with the latest manifest, ensures only one artifact is uploaded
+
+      - name: Send email notification on failure
+        if: failure()
+        run: |
+          echo "::error::dbt Production run failed. Check the workflow logs for details."
+          echo "GitHub will send email notifications to watchers if email notifications are enabled."


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add hourly dbt production workflow with state-based runs and update README to document CI and prod workflows, setup, and notifications.
> 
> - **CI/CD**:
>   - **New production workflow**: Adds `/.github/workflows/dbt_prod.yml` to run dbt hourly on `main`.
>     - Installs deps via `uv`, runs `dbt deps/compile/run/test`.
>     - Uses artifacted `manifest.json` for `state:modified+` selection when available.
>     - Always runs full project afterward, then tests; uploads new manifest; logs failure notice.
>   - **Docs**: Updates `README.md` CI/CD section.
>     - Splits into PR CI and scheduled production workflows with step summaries.
>     - Explains state comparison, required `DUNE_API_KEY` secret, optional `DUNE_TEAM_NAME` variable, and email notification setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0eb36b9cd73b3ff0d99daee5c3a963e90bdbbf5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->