### PR TITLE
prod workflow: fix bug on finding previous run manifest

### DIFF
--- a/.github/workflows/dbt_prod.yml
+++ b/.github/workflows/dbt_prod.yml
@@ -34,11 +34,13 @@ jobs:
       - name: Download previous manifest for state comparison
         id: download-manifest
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: dawidd6/action-download-artifact@v6
         with:
           name: prod-manifest-latest
           path: ./state
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: dbt_prod.yml
+          branch: main
+          if_no_artifact_found: warn
 
       - name: Compile current models
         run: uv run dbt compile


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switch artifact download action and parameters to reliably fetch the previous run's manifest in the dbt prod workflow.
> 
> - **CI (dbt prod workflow)**:
>   - Replace `actions/download-artifact@v4` with `dawidd6/action-download-artifact@v6` in `Download previous manifest` step.
>   - Configure inputs: `workflow: dbt_prod.yml`, `branch: main`, `if_no_artifact_found: warn`; remove `github-token`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9365578a19180628ffe64d421d0538ff99b5fbfc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->