### PR TITLE
CUR2-796 remove refs to dev api endpoint, clarify dev and prod usage

### DIFF
--- a/.github/workflows/dbt_prod.yml
+++ b/.github/workflows/dbt_prod.yml
@@ -13,6 +13,7 @@ jobs:
     env:
       DUNE_API_KEY: ${{ secrets.DUNE_API_KEY }}
       DUNE_TEAM_NAME: ${{ vars.DUNE_TEAM_NAME || 'dune' }}  # Set as GitHub Variable or defaults to 'dune'
+      DBT_TARGET: prod  # All dbt commands will use the prod target from profiles.yml
     
     steps:
       - name: Check out code

--- a/profiles.yml
+++ b/profiles.yml
@@ -6,7 +6,7 @@ dbt_template:
       type: trino
       user: dune # do not change: user is always 'dune'
       password: "{{ env_var('DUNE_API_KEY') }}"
-      host: dune-api-trino.dev.dune.com
+      host: dune-api-trino.dune.com
       port: 443
       method: ldap
       catalog: dune # do not change: catalog is always 'dune'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Points dbt to the production Trino host, sets the scheduled workflow to use the prod target, and updates docs to clarify dev/prod targets and schema naming.
> 
> - **Config**:
>   - Switch `profiles.yml` dev output `host` to `dune-api-trino.dune.com` (removes `.dev` endpoint).
> - **CI/CD**:
>   - `.github/workflows/dbt_prod.yml`: set `DBT_TARGET=prod` for production runs.
> - **Docs**:
>   - `README.md`: Clarify target usage and schema naming (dev vs prod), add instructions for using `--target prod`, and describe CI (PR uses dev with suffix) vs scheduled prod runs.
>   - Note macro-based schema control: `macros/dune_dbt_overrides/get_custom_schema.sql` governs schema names by target.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6646ca2d3dde9b30932a641e8d3379b4b8bfa79a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->