### PR TITLE
README: add section to clarify catalog usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,23 +70,20 @@ dbt docs generate && dbt docs serve # View documentation
 
 ## Querying Models on Dune App/API
 
-⚠️ **Important:** When querying models built by this dbt project on the Dune app or API, you **must** include the `dune` catalog name.
+⚠️ **Important:** Models must be queried with the `dune` catalog prefix on Dune app/API.
 
-**Incorrect (won't work):**
+**Pattern:** `dune.{team_name}.{table}` (where `{team_name}` = `DUNE_TEAM_NAME` from `.env`)
+
 ```sql
-select * from dbt_template_view_model
+-- ❌ Won't work
 select * from dune__tmp_.dbt_template_view_model
-```
 
-**Correct:**
-```sql
+-- ✅ Correct (with DUNE_TEAM_NAME=dune)
 select * from dune.dune.dbt_template_view_model
 select * from dune.dune__tmp_.dbt_template_view_model
 ```
 
-**Pattern:** `dune.{schema}.{table}`
-
-**Note:** dbt logs don't output the catalog name, so you can't directly copy-paste queries from dbt output. You must add `dune.` prefix to the schema when querying in Dune.
+**Note:** dbt logs omit the catalog name, so copy-pasting queries from dbt output won't work directly—you must prepend `dune.` to the schema.
 
 ## Model Templates
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,26 @@ dbt test --select model_name        # Test specific model
 dbt docs generate && dbt docs serve # View documentation
 ```
 
+## Querying Models on Dune App/API
+
+⚠️ **Important:** When querying models built by this dbt project on the Dune app or API, you **must** include the `dune` catalog name.
+
+**Incorrect (won't work):**
+```sql
+select * from dbt_template_view_model
+select * from dune__tmp_.dbt_template_view_model
+```
+
+**Correct:**
+```sql
+select * from dune.dune.dbt_template_view_model
+select * from dune.dune__tmp_.dbt_template_view_model
+```
+
+**Pattern:** `dune.{schema}.{table}`
+
+**Note:** dbt logs don't output the catalog name, so you can't directly copy-paste queries from dbt output. You must add `dune.` prefix to the schema when querying in Dune.
+
 ## Model Templates
 
 | Type | File | Use Case |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a README section explaining that queries on Dune must include the `dune` catalog prefix, with correct/incorrect examples and pattern.
> 
> - **Documentation**:
>   - **`README.md`**:
>     - Adds a new section "Querying Models on Dune App/API" clarifying that queries must include the `dune` catalog (pattern `dune.{schema}.{table}`).
>     - Provides correct/incorrect examples and notes that dbt logs omit the catalog, requiring manual `dune.` prefixing when querying.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 111edca8a5eb892359fd3bdaa90e6ab37ebe3fb6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->