### PR TITLE
pause prod schedule for template

### DIFF
--- a/.github/workflows/dbt_prod.yml
+++ b/.github/workflows/dbt_prod.yml
@@ -1,8 +1,9 @@
 name: dbt prod orchestration
 
 on:
-  schedule:
-    - cron: '0 * * * *'  # Run every hour at minute 0
+  # schedule:
+  #   - cron: '0 * * * *'  # Run every hour at minute 0
+  # NOTE: Schedule is disabled by default. Uncomment when ready to enable hourly production runs.
   workflow_dispatch:  # Allow manual triggers
 
 jobs:

--- a/SETUP_FOR_NEW_TEAMS.md
+++ b/SETUP_FOR_NEW_TEAMS.md
@@ -134,6 +134,25 @@ Verify:
 - ✅ Models run successfully
 - ✅ Tests pass
 
+## 6. Enable Production Schedule (Optional)
+
+The production workflow is **disabled by default** to prevent automatic runs on new repos.
+
+**When you're ready for hourly production runs:**
+
+Edit `.github/workflows/dbt_prod.yml`:
+```yaml
+on:
+  schedule:
+    - cron: '0 * * * *'  # Uncomment these lines
+  workflow_dispatch:
+```
+
+**Before enabling:**
+- ✅ CI tests are passing
+- ✅ You've tested production runs manually (Actions → dbt prod orchestration → Run workflow)
+- ✅ You understand this will run every hour and consume GitHub Actions minutes
+
 ## Troubleshooting
 
 If CI fails with "Secret not found":

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -53,9 +53,11 @@ dbt test --select modified_model
 
 ## Production Workflow
 
-**Trigger:** Hourly (on schedule) or manual  
+**Trigger:** Manual (schedule disabled by default)  
 **File:** `.github/workflows/dbt_prod.yml`  
 **Branch:** `main` only
+
+⚠️ **Note:** The hourly schedule is **disabled by default** in the template. Teams must uncomment the schedule in the workflow file when ready to enable automatic hourly runs.
 
 ### What It Does
 
@@ -119,7 +121,7 @@ Runs when:
 ### Production Workflow
 
 Runs when:
-- Hourly (cron: `'0 * * * *'`)
+- Hourly (cron: `'0 * * * *'`) - **disabled by default, must be uncommented**
 - Manual trigger via GitHub Actions UI
 
 ## Troubleshooting CI Failures


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Disables the hourly cron for `dbt_prod` by default and updates docs with instructions to enable the schedule when ready.
> 
> - **CI/CD**:
>   - **` .github/workflows/dbt_prod.yml`**: Comment out `schedule` cron (disable hourly runs by default); keep `workflow_dispatch`; add note explaining how to re-enable.
> - **Docs**:
>   - **`docs/cicd.md`**: Update production workflow trigger to manual by default; add warning/note that hourly cron is disabled and must be uncommented; adjust trigger section accordingly.
>   - **`SETUP_FOR_NEW_TEAMS.md`**: Add section “Enable Production Schedule (Optional)” with steps to uncomment cron and readiness checklist.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eedfa99de25665160b905b8e39d2b63db1da641e. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->