### PR TITLE
manifest artifact: revert back to workflow name for manifest search

### DIFF
--- a/.github/workflows/dbt_ci.yml
+++ b/.github/workflows/dbt_ci.yml
@@ -45,13 +45,13 @@ jobs:
         continue-on-error: true
         # Using dawidd6/action-download-artifact instead of actions/download-artifact
         # because the official action only downloads artifacts from the same workflow run,
-        # while we need to download the manifest from the dbt_deploy workflow.
+        # while we need to download the manifest from the most recent successful dbt_deploy run.
         uses: dawidd6/action-download-artifact@v6
         with:
           name: prod-manifest-latest
           path: ./state
+          workflow: dbt_deploy.yml
           branch: main
-          search_artifacts: true  # Search across all workflows for the artifact
           if_no_artifact_found: ignore  # Let our verification step handle the error with detailed message
 
       - name: Verify manifest exists

--- a/.github/workflows/dbt_deploy.yml
+++ b/.github/workflows/dbt_deploy.yml
@@ -49,13 +49,13 @@ jobs:
         continue-on-error: true
         # Using dawidd6/action-download-artifact instead of actions/download-artifact
         # because the official action only downloads artifacts from the same workflow run,
-        # while we need to download the manifest from previous runs of this workflow.
+        # while we need to download the manifest from the most recent successful run of this workflow.
         uses: dawidd6/action-download-artifact@v6
         with:
           name: prod-manifest-latest
           path: ./state
+          workflow: dbt_deploy.yml
           branch: main
-          search_artifacts: true  # Search across all workflows for the artifact
           if_no_artifact_found: warn
 
       - name: Compile current models


### PR DESCRIPTION
using `search_artifacts: true` did not work without a workflow name specified. this was difficult to test in PR phase without a deployment to main.

reverting back to the original idea of searching the only workflow which uploads, and the action by default finds most recent successful run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Scopes manifest artifact downloads to the most recent successful dbt_deploy workflow by specifying the workflow in the download steps.
> 
> - **CI/CD Workflows**:
>   - `dbt_ci.yml`:
>     - Scope manifest download to the most recent successful `dbt_deploy.yml` run by setting `workflow: dbt_deploy.yml` in `dawidd6/action-download-artifact`.
>     - Remove `search_artifacts` and update comments accordingly.
>   - `dbt_deploy.yml`:
>     - Same scoping for previous manifest download (`workflow: dbt_deploy.yml`); remove `search_artifacts` and update comments.
>     - No changes to behavior of subsequent steps (compile/run/test/upload).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f05f2664c31772957459acbf4667d30796a564da. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->