### PR TITLE
CUR2-878 update docs to disable workflow runs for outside contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,9 @@ Runs hourly on main branch. Uses state comparison to only full refresh modified 
 1. Add Secret: `DUNE_API_KEY` (Settings → Secrets and variables → Actions → Secrets)
 2. Add Variable: `DUNE_TEAM_NAME` (Settings → Secrets and variables → Actions → Variables)
    - Optional, defaults to `'dune'` if not set
-3. **Public repos:** Require approval for outside contributor workflows (Settings → Actions → General → Fork pull request workflows)
+
+**Recommended:**
+1. **Public repos:** Require approval for outside contributor workflows (Settings → Actions → General → Fork pull request workflows)
    - Protects secrets from unauthorized access
    - See [SETUP_FOR_NEW_TEAMS.md](SETUP_FOR_NEW_TEAMS.md#fork-pull-request-workflow-permissions-required-for-public-repos) for details
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,9 @@ Runs hourly on main branch. Uses state comparison to only full refresh modified 
 1. Add Secret: `DUNE_API_KEY` (Settings → Secrets and variables → Actions → Secrets)
 2. Add Variable: `DUNE_TEAM_NAME` (Settings → Secrets and variables → Actions → Variables)
    - Optional, defaults to `'dune'` if not set
+3. **Public repos:** Require approval for outside contributor workflows (Settings → Actions → General → Fork pull request workflows)
+   - Protects secrets from unauthorized access
+   - See [SETUP_FOR_NEW_TEAMS.md](SETUP_FOR_NEW_TEAMS.md#fork-pull-request-workflow-permissions-required-for-public-repos) for details
 
 **Email notifications:**
 1. Enable workflow notifications: Profile → Settings → Notifications → Actions → "Notify me for failed workflows only"

--- a/SETUP_FOR_NEW_TEAMS.md
+++ b/SETUP_FOR_NEW_TEAMS.md
@@ -19,6 +19,21 @@ Settings → Actions → General:
 
 **Note:** This template uses GitHub-hosted runners (`ubuntu-latest`). GitHub provides and manages these automatically.
 
+### Fork Pull Request Workflow Permissions (Required for Public Repos)
+
+**Important:** If this is a public repository, protect your secrets and workflows from unauthorized use.
+
+Settings → Actions → General → Fork pull request workflows from outside collaborators:
+- ✅ **Require approval for all outside collaborators** (most secure, recommended)
+- OR: Require approval for first-time contributors
+
+**Why this matters:**
+- Workflows have access to secrets like `DUNE_API_KEY`
+- Protect team account from unnecessary workflow runs which consume credits
+- This setting requires a maintainer to manually approve workflow runs from non-org members
+
+**Note:** This only affects public repositories. Private repos automatically restrict workflow access to org members.
+
 ## 2. GitHub Secrets & Variables
 
 ### Required Secrets


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Document GitHub settings for public repos to require maintainer approval for outside contributor workflow runs and link to detailed setup guidance.
> 
> - **Docs**:
>   - **README**: Add GitHub setup step for public repos to require approval for outside contributor workflows, noting secret protection and linking to `SETUP_FOR_NEW_TEAMS.md` for details.
>   - **SETUP_FOR_NEW_TEAMS.md**: Introduce "Fork Pull Request Workflow Permissions (Required for Public Repos)" with settings path, recommended approval options, rationale (secret protection/credits), and note that private repos are unaffected.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eba5c246e918e8fc67936c457238bb90563850cc. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->