### PR TITLE
init script to drop tables and views across envs

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ models/          # dbt models and templates
 macros/          # Custom Dune macros (schema overrides, sources)
   └── dune_dbt_overrides/
       └── get_custom_schema.sql  # Controls schema naming based on target
+scripts/         # Utility scripts for managing your Dune dbt project
+  └── drop_tables.py  # Drop tables/views by schema pattern or specific table
 .cursor/         # Cursor AI rules (dbt-best-practices.mdc)
   └── rules/
       └── dbt-best-practices.mdc  # dbt patterns and configurations
@@ -241,6 +243,10 @@ The `get_custom_schema.sql` macro determines where models are written based on t
 | `dev` | Set to `alice` | `{team}__tmp_alice` | Personal dev space |
 
 This ensures safe isolation between development and production environments.
+
+## Utility Scripts
+
+The `scripts/` directory contains utility scripts for managing tables and schemas. See [scripts/README.md](scripts/README.md) for details.
 
 ## Links
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.12"
 dependencies = [
     "dbt-core>=1.10.13",
     "dbt-trino>=1.9.3",
+    "trino>=0.329.0",
 ]
 
 [project.scripts]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,257 @@
+# Scripts
+
+This directory contains utility scripts for managing your Dune dbt project.
+
+## drop_tables.py
+
+Drops tables and views in a Dune schema via the Trino API endpoint.
+
+### Purpose
+
+This script connects to the Dune Trino API using the same configuration as dbt and drops tables and views based on:
+- **Target environment** (dev or prod)
+  - `dev` (default): Drops all tables matching `{DUNE_TEAM_NAME}__tmp_%` pattern (bulk drops allowed)
+  - `prod`: **Only allows dropping ONE specific table/view at a time** (requires `--schema` and `--table`)
+- **Schema pattern matching** (dev only - override with `--schema` for custom patterns)
+- **Specific table/view** (drop a single table or view)
+
+The script uses `INFORMATION_SCHEMA.TABLES` to find tables and generates appropriate `DROP TABLE` or `DROP VIEW` commands based on the object type.
+
+**⚠️ Important Note on Storage**: 
+- Trino's `DROP TABLE` command only removes the metastore entry, **leaving orphaned data in S3**
+- S3 cleanup should be handled separately via scheduled cleanup jobs
+- This script does not clean up S3 data (requires separate AWS access)
+
+**Production Safety**: 
+- Prod drops require BOTH `--schema` AND `--table` (no bulk drops)
+- Interactive confirmation is required before executing prod drops
+- This ensures prod drops are deliberate, specific, and rare
+
+### Prerequisites
+
+- Ensure you have set the `DUNE_API_KEY` environment variable
+- Optionally set `DUNE_TEAM_NAME` environment variable (defaults to 'dune')
+- Install dependencies: `uv sync`
+
+### Usage
+
+#### Drop Dev Tables (Default)
+
+By default, the script uses `dev` target and matches all schemas starting with `{DUNE_TEAM_NAME}__tmp_`:
+
+```bash
+# Dry run - drops all tables in dev schemas matching dune__tmp_*
+# This includes dune__tmp_, dune__tmp_pr123, dune__tmp_jeff, etc.
+python scripts/drop_tables.py
+
+# Execute - actually drop dev tables
+python scripts/drop_tables.py --execute
+```
+
+**Dev pattern matching uses SQL LIKE**: The pattern `dune__tmp_%` will match:
+- `dune__tmp_` (exact match)
+- `dune__tmp_pr123` (with PR number suffix)
+- `dune__tmp_alice` (with user suffix)
+- Any other schema starting with `dune__tmp_`
+
+#### Drop Prod Tables
+
+⚠️ **Production Restriction**: For safety, prod drops require BOTH `--schema` AND `--table`.
+
+You can only drop **one specific table/view at a time** in prod. Bulk drops are not allowed.
+
+```bash
+# Dry run - drop specific prod table
+python scripts/drop_tables.py --target prod --schema dune --table my_table
+
+# Execute - drop specific prod table (REQUIRES CONFIRMATION)
+python scripts/drop_tables.py --target prod --schema dune --table my_table --execute
+```
+
+**⚠️ Production Safety**: When using `--target prod` with `--execute`:
+1. You MUST specify both `--schema` and `--table` (no pattern matching)
+2. Script confirms the specific table that will be dropped
+3. Requires you to type `yes` to confirm
+4. Operation is cancelled if you type anything else or press Ctrl+C
+
+**This restriction ensures prod drops are deliberate, specific, and rare.**
+
+#### Drop Specific Schema
+
+Drop all tables in a specific schema (exact match):
+
+```bash
+# Dry run - show what would be dropped
+python scripts/drop_tables.py --schema my_custom_schema
+
+# Execute - actually drop the tables
+python scripts/drop_tables.py --schema my_custom_schema --execute
+```
+
+#### Drop Specific Table/View
+
+Drop a single table or view:
+
+```bash
+# Dry run - show what would be dropped
+python scripts/drop_tables.py --table my_table_name --schema my_schema
+
+# Execute - actually drop the table
+python scripts/drop_tables.py --table my_table_name --schema my_schema --execute
+```
+
+**Note**: When dropping a specific table, you must provide the exact schema name (not a pattern).
+
+#### Additional Options
+
+```bash
+# Verbose logging for debugging
+python scripts/drop_tables.py --verbose
+
+# Specify API key directly (instead of using env var)
+python scripts/drop_tables.py --execute --api-key YOUR_API_KEY_HERE
+```
+
+### Command-Line Arguments
+
+| Argument | Description | Default |
+|----------|-------------|---------|
+| `--target` | Target environment: `dev` or `prod` | `dev` |
+| `--schema` | Schema name or pattern (overrides `--target`) | None (uses target default) |
+| `--table` | Specific table/view name (requires `--schema`) | None (drops all) |
+| `--execute` | Execute the drop operations (default is dry-run) | False |
+| `--api-key` | Dune API key | `DUNE_API_KEY` env var |
+| `--verbose`, `-v` | Enable verbose (debug) logging | False |
+
+**Target Defaults**:
+- `dev`: Uses schema pattern `{DUNE_TEAM_NAME}__tmp_%` (matches all dev schemas)
+- `prod`: Uses schema `{DUNE_TEAM_NAME}` (exact production schema)
+
+### Examples
+
+```bash
+# Drop all dev tables (dry run - default target)
+python scripts/drop_tables.py
+
+# Drop all dev tables (execute)
+python scripts/drop_tables.py --execute
+
+# Drop all tables in specific dev schema (dry run)
+python scripts/drop_tables.py --schema dune__tmp_pr123
+
+# Drop all tables in specific dev schema (execute)
+python scripts/drop_tables.py --schema dune__tmp_pr123 --execute
+
+# Drop specific dev table (dry run)
+python scripts/drop_tables.py --table my_model --schema dune__tmp_jeff
+
+# Drop specific dev table (execute)
+python scripts/drop_tables.py --table my_model --schema dune__tmp_jeff --execute
+
+# Drop specific PROD table (dry run - REQUIRES --schema AND --table)
+python scripts/drop_tables.py --target prod --schema dune --table my_model
+
+# Drop specific PROD table (execute - REQUIRES CONFIRMATION)
+python scripts/drop_tables.py --target prod --schema dune --table my_model --execute
+
+# Drop with custom pattern (any dev schema starting with 'test_')
+python scripts/drop_tables.py --schema test_% --execute
+
+# Verbose output for debugging
+python scripts/drop_tables.py --verbose
+```
+
+### Output
+
+#### Dry Run Mode (Default)
+
+Shows all DROP commands that would be executed:
+
+```
+2025-11-09 15:12:47 - __main__ - WARNING - ================================================================================
+2025-11-09 15:12:47 - __main__ - WARNING - DRY RUN MODE - No operations will be executed
+2025-11-09 15:12:47 - __main__ - WARNING - To execute operations, add the --execute flag
+2025-11-09 15:12:47 - __main__ - WARNING - ================================================================================
+2025-11-09 15:12:47 - __main__ - INFO - Target: All tables matching schema pattern 'dune__tmp_%'
+2025-11-09 15:12:47 - __main__ - INFO - Initialized Dune Trino connection config (host=trino.api.dune.com, catalog=dune)
+2025-11-09 15:12:47 - __main__ - INFO - Connecting to Dune Trino API...
+2025-11-09 15:12:47 - __main__ - INFO - Successfully connected to Dune Trino API
+2025-11-09 15:12:47 - __main__ - INFO - Querying tables matching schema pattern: dune__tmp_%
+2025-11-09 15:12:49 - __main__ - INFO - ================================================================================
+2025-11-09 15:12:49 - __main__ - INFO - Preparing to drop 305 table(s)/view(s)
+2025-11-09 15:12:49 - __main__ - INFO - ================================================================================
+2025-11-09 15:12:49 - __main__ - INFO - DROP: drop table if exists dune.dune__tmp_jeff.my_table
+2025-11-09 15:12:49 - __main__ - INFO - DROP: drop view if exists dune.dune__tmp_jeff.my_view
+2025-11-09 15:12:49 - __main__ - INFO - DROP: drop table if exists dune.dune__tmp_pr123.another_table
+...
+2025-11-09 15:12:49 - __main__ - INFO - ================================================================================
+2025-11-09 15:12:49 - __main__ - INFO - Drop summary: 305 successful, 0 failed
+2025-11-09 15:12:49 - __main__ - INFO - ================================================================================
+2025-11-09 15:12:49 - __main__ - INFO - 
+2025-11-09 15:12:49 - __main__ - INFO - ================================================================================
+2025-11-09 15:12:49 - __main__ - INFO - DRY RUN COMPLETE
+2025-11-09 15:12:49 - __main__ - INFO - Above are the DROP commands that would be executed.
+2025-11-09 15:12:49 - __main__ - INFO - Use --execute flag to actually drop the tables/views.
+2025-11-09 15:12:49 - __main__ - INFO - ================================================================================
+2025-11-09 15:12:49 - __main__ - INFO - Connection closed
+```
+
+#### Execute Mode
+
+When executing with `--execute`, each drop is confirmed with ✓ or ✗:
+
+```
+2025-11-09 15:15:00 - __main__ - INFO - DROP: drop table if exists dune.dune__tmp_jeff.my_table
+2025-11-09 15:15:01 - __main__ - INFO - ✓ Successfully dropped: dune__tmp_jeff.my_table
+2025-11-09 15:15:01 - __main__ - INFO - DROP: drop view if exists dune.dune__tmp_jeff.my_view
+2025-11-09 15:15:02 - __main__ - INFO - ✓ Successfully dropped: dune__tmp_jeff.my_view
+...
+2025-11-09 15:15:10 - __main__ - INFO - ================================================================================
+2025-11-09 15:15:10 - __main__ - INFO - Drop summary: 305 successful, 0 failed
+2025-11-09 15:15:10 - __main__ - INFO - ================================================================================
+```
+
+### Connection Details
+
+The script uses the following connection configuration (matching `profiles.yml`):
+
+- **Host**: `trino.api.dune.com`
+- **Port**: `443`
+- **User**: `dune` (fixed)
+- **Catalog**: `dune` (fixed)
+- **Authentication**: Basic auth with DUNE_API_KEY
+- **HTTP Scheme**: HTTPS
+- **Session Properties**: `transformations: true`
+
+### How It Works
+
+1. Reads `DUNE_API_KEY` and `DUNE_TEAM_NAME` from environment variables
+2. Establishes a connection to Dune's Trino API endpoint
+3. Queries `INFORMATION_SCHEMA.TABLES` based on the target:
+   - **Pattern mode**: Uses `LIKE` to match schema names (e.g., `dune__tmp_%`)
+   - **Specific schema**: Queries exact schema name
+   - **Specific table**: Queries for exact schema and table name
+4. For each table/view found:
+   - Generates appropriate `DROP TABLE` or `DROP VIEW` command based on type
+   - Logs the DROP command (visible in both dry run and execute modes)
+   - If `--execute` flag is set, executes the DROP command
+5. Displays a summary of successful and failed drops
+6. Closes the connection
+
+**Pattern Matching Behavior:**
+- Default pattern `{DUNE_TEAM_NAME}__tmp_%` matches all dev schemas
+- The `%` wildcard matches any characters (including none)
+- You can provide custom patterns with `--schema` (e.g., `test_%`, `staging_%`)
+
+This approach is particularly useful for:
+- Cleaning up all dev schemas at once (including PR schemas)
+- Cleaning up after CI/CD test runs
+- Removing temporary tables from pattern-matched schemas
+
+### Safety Features
+
+- **Dry run by default**: Prevents accidental deletions
+- **Clear logging**: All DROP commands are displayed before execution
+- **Pattern visibility**: Shows which schemas are matched before dropping
+- **Summary reporting**: Confirms what was dropped and if any failures occurred
+- **Uses `IF EXISTS`**: DROP commands won't fail if table doesn't exist

--- a/scripts/drop_tables.py
+++ b/scripts/drop_tables.py
@@ -122,8 +122,8 @@ def list_tables_by_pattern(
     """
     cursor = connection.cursor()
 
-    # Use LIKE pattern matching for schema
-    query = f"""
+    # Use parameterized query to prevent SQL injection
+    query = """
         select
             table_schema
             , table_name
@@ -131,8 +131,8 @@ def list_tables_by_pattern(
         from
             dune.information_schema.tables
         where
-            table_catalog = '{catalog}'
-            and table_schema like '{schema_pattern}'
+            table_catalog = ?
+            and table_schema like ?
         order by
             table_schema
             , table_name
@@ -140,9 +140,10 @@ def list_tables_by_pattern(
 
     logger.info(f"Querying tables matching schema pattern: {schema_pattern}")
     logger.debug(f"Query: {query}")
+    logger.debug(f"Parameters: catalog={catalog}, schema_pattern={schema_pattern}")
 
     try:
-        cursor.execute(query)
+        cursor.execute(query, (catalog, schema_pattern))
         results = cursor.fetchall()
 
         tables = []
@@ -182,7 +183,8 @@ def list_specific_table(
     """
     cursor = connection.cursor()
 
-    query = f"""
+    # Use parameterized query to prevent SQL injection
+    query = """
         select
             table_schema
             , table_name
@@ -190,16 +192,17 @@ def list_specific_table(
         from
             dune.information_schema.tables
         where
-            table_catalog = '{catalog}'
-            and table_schema = '{schema}'
-            and table_name = '{table_name}'
+            table_catalog = ?
+            and table_schema = ?
+            and table_name = ?
     """
 
     logger.info(f"Querying table: {catalog}.{schema}.{table_name}")
     logger.debug(f"Query: {query}")
+    logger.debug(f"Parameters: catalog={catalog}, schema={schema}, table_name={table_name}")
 
     try:
-        cursor.execute(query)
+        cursor.execute(query, (catalog, schema, table_name))
         results = cursor.fetchall()
 
         tables = []
@@ -217,6 +220,30 @@ def list_specific_table(
         raise
     finally:
         cursor.close()
+
+
+def quote_identifier(identifier: str) -> str:
+    """
+    Quote a SQL identifier to prevent SQL injection in DDL statements.
+    
+    In Trino, identifiers can be quoted with double quotes.
+    This function validates and quotes identifiers safely.
+    
+    Args:
+        identifier: SQL identifier to quote
+        
+    Returns:
+        str: Quoted identifier
+        
+    Raises:
+        ValueError: If identifier contains quotes or is invalid
+    """
+    # Validate: no double quotes allowed (would break quoting)
+    if '"' in identifier:
+        raise ValueError(f"Invalid identifier: contains double quotes: {identifier}")
+    
+    # Quote the identifier
+    return f'"{identifier}"'
 
 
 def drop_table_or_view(
@@ -241,11 +268,20 @@ def drop_table_or_view(
     Returns:
         bool: True if successful (or dry run), False otherwise
     """
-    # Determine if this is a table or view
-    if table_type == "VIEW":
-        drop_statement = f"drop view if exists {catalog}.{schema}.{table_name}"
-    else:  # BASE TABLE or other types
-        drop_statement = f"drop table if exists {catalog}.{schema}.{table_name}"
+    try:
+        # Quote identifiers to prevent SQL injection in DDL statements
+        quoted_catalog = quote_identifier(catalog)
+        quoted_schema = quote_identifier(schema)
+        quoted_table = quote_identifier(table_name)
+        
+        # Determine if this is a table or view
+        if table_type == "VIEW":
+            drop_statement = f"drop view if exists {quoted_catalog}.{quoted_schema}.{quoted_table}"
+        else:  # BASE TABLE or other types
+            drop_statement = f"drop table if exists {quoted_catalog}.{quoted_schema}.{quoted_table}"
+    except ValueError as e:
+        logger.error(f"✗ Invalid identifier for {schema}.{table_name}: {e}")
+        return False
 
     # Always log the drop command
     logger.info(f"DROP: {drop_statement}")

--- a/scripts/drop_tables.py
+++ b/scripts/drop_tables.py
@@ -1,0 +1,554 @@
+#!/usr/bin/env python3
+"""
+Script to drop tables and views in a Dune schema via Trino API.
+
+This script connects to the Dune Trino API endpoint using the same configuration
+as dbt and drops tables and views based on schema pattern or specific table name.
+
+NOTE: Trino's DROP TABLE command only removes the metastore entry, leaving orphaned
+data in S3. S3 cleanup should be handled separately via scheduled cleanup jobs.
+
+Usage:
+    # Dry run - drop all tables matching DUNE_TEAM_NAME__tmp_* pattern
+    python scripts/drop_tables.py
+
+    # Dry run - drop all tables in specific schema
+    python scripts/drop_tables.py --schema my_custom_schema
+
+    # Dry run - drop specific table
+    python scripts/drop_tables.py --table my_table_name --schema my_schema
+
+    # Actually execute drops
+    python scripts/drop_tables.py --execute
+
+    # Execute drop for specific schema
+    python scripts/drop_tables.py --schema my_schema --execute
+"""
+
+import argparse
+import logging
+import os
+import sys
+from typing import Optional
+
+import trino
+
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+
+class DuneTrinoConnection:
+    """Manages connection to Dune Trino API endpoint."""
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        host: str = "trino.api.dune.com",
+        port: int = 443,
+        catalog: str = "dune",
+    ):
+        """
+        Initialize Dune Trino connection.
+
+        Args:
+            api_key: Dune API key (defaults to DUNE_API_KEY env var)
+            host: Trino host endpoint
+            port: Trino port
+            catalog: Trino catalog
+        """
+        self.api_key = api_key or os.getenv("DUNE_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "DUNE_API_KEY environment variable is required or pass api_key parameter"
+            )
+
+        self.host = host
+        self.port = port
+        self.catalog = catalog
+        self.connection = None
+
+        logger.info(f"Initialized Dune Trino connection config (host={host}, catalog={catalog})")
+
+    def connect(self) -> trino.dbapi.Connection:
+        """
+        Establish connection to Dune Trino API.
+
+        Returns:
+            trino.dbapi.Connection: Active Trino connection
+        """
+        logger.info("Connecting to Dune Trino API...")
+
+        self.connection = trino.dbapi.connect(
+            host=self.host,
+            port=self.port,
+            user="dune",  # Always 'dune' for Dune API
+            catalog=self.catalog,
+            http_scheme="https",
+            auth=trino.auth.BasicAuthentication("dune", self.api_key),
+            session_properties={"transformations": "true"},
+        )
+
+        logger.info("Successfully connected to Dune Trino API")
+        return self.connection
+
+    def close(self):
+        """Close the Trino connection."""
+        if self.connection:
+            self.connection.close()
+            logger.info("Connection closed")
+
+
+def list_tables_by_pattern(
+    connection: trino.dbapi.Connection,
+    schema_pattern: str,
+    catalog: str = "dune",
+) -> list:
+    """
+    List all tables matching a schema pattern.
+
+    Args:
+        connection: Active Trino connection
+        schema_pattern: Schema pattern to match (e.g., 'my_team__tmp_%' for LIKE matching)
+        catalog: Catalog name (default: 'dune')
+
+    Returns:
+        list: List of dicts with schema, table name, and type
+    """
+    cursor = connection.cursor()
+
+    # Use LIKE pattern matching for schema
+    query = f"""
+        select
+            table_schema
+            , table_name
+            , table_type
+        from
+            dune.information_schema.tables
+        where
+            table_catalog = '{catalog}'
+            and table_schema like '{schema_pattern}'
+        order by
+            table_schema
+            , table_name
+    """
+
+    logger.info(f"Querying tables matching schema pattern: {schema_pattern}")
+    logger.debug(f"Query: {query}")
+
+    try:
+        cursor.execute(query)
+        results = cursor.fetchall()
+
+        tables = []
+        for row in results:
+            schema_name, table_name, table_type = row
+            tables.append({
+                "schema": schema_name,
+                "name": table_name,
+                "type": table_type,
+            })
+
+        return tables
+    except Exception as e:
+        logger.error(f"Error querying tables: {e}")
+        raise
+    finally:
+        cursor.close()
+
+
+def list_specific_table(
+    connection: trino.dbapi.Connection,
+    schema: str,
+    table_name: str,
+    catalog: str = "dune",
+) -> list:
+    """
+    List a specific table in a schema.
+
+    Args:
+        connection: Active Trino connection
+        schema: Schema name
+        table_name: Table name
+        catalog: Catalog name (default: 'dune')
+
+    Returns:
+        list: List with single dict containing table info, or empty list if not found
+    """
+    cursor = connection.cursor()
+
+    query = f"""
+        select
+            table_schema
+            , table_name
+            , table_type
+        from
+            dune.information_schema.tables
+        where
+            table_catalog = '{catalog}'
+            and table_schema = '{schema}'
+            and table_name = '{table_name}'
+    """
+
+    logger.info(f"Querying table: {catalog}.{schema}.{table_name}")
+    logger.debug(f"Query: {query}")
+
+    try:
+        cursor.execute(query)
+        results = cursor.fetchall()
+
+        tables = []
+        for row in results:
+            schema_name, table_name_result, table_type = row
+            tables.append({
+                "schema": schema_name,
+                "name": table_name_result,
+                "type": table_type,
+            })
+
+        return tables
+    except Exception as e:
+        logger.error(f"Error querying table: {e}")
+        raise
+    finally:
+        cursor.close()
+
+
+def drop_table_or_view(
+    connection: trino.dbapi.Connection,
+    schema: str,
+    table_name: str,
+    table_type: str,
+    catalog: str = "dune",
+    dry_run: bool = True,
+) -> bool:
+    """
+    Drop a table or view from the specified schema.
+
+    Args:
+        connection: Active Trino connection
+        schema: Schema name
+        table_name: Name of the table/view to drop
+        table_type: Type of object ('BASE TABLE' or 'VIEW')
+        catalog: Catalog name (default: 'dune')
+        dry_run: If True, only log the command without executing
+
+    Returns:
+        bool: True if successful (or dry run), False otherwise
+    """
+    # Determine if this is a table or view
+    if table_type == "VIEW":
+        drop_statement = f"drop view if exists {catalog}.{schema}.{table_name}"
+    else:  # BASE TABLE or other types
+        drop_statement = f"drop table if exists {catalog}.{schema}.{table_name}"
+
+    # Always log the drop command
+    logger.info(f"DROP: {drop_statement}")
+
+    if dry_run:
+        logger.debug("Dry run mode - command not executed")
+        return True
+
+    # Execute the drop command
+    cursor = connection.cursor()
+    try:
+        cursor.execute(drop_statement)
+        logger.info(f"✓ Successfully dropped: {schema}.{table_name}")
+        return True
+    except Exception as e:
+        logger.error(f"✗ Error dropping {schema}.{table_name}: {e}")
+        return False
+    finally:
+        cursor.close()
+
+
+def drop_tables(
+    connection: trino.dbapi.Connection,
+    tables: list,
+    catalog: str = "dune",
+    dry_run: bool = True,
+) -> dict:
+    """
+    Drop tables and views from the list.
+
+    Args:
+        connection: Active Trino connection
+        tables: List of table dicts with 'schema', 'name', and 'type'
+        catalog: Catalog name (default: 'dune')
+        dry_run: If True, only log the commands without executing
+
+    Returns:
+        dict: Summary with counts of successful and failed drops
+    """
+    if not tables:
+        logger.info("No tables found to drop.")
+        return {"total": 0, "success": 0, "failed": 0}
+
+    logger.info("=" * 80)
+    logger.info(f"Preparing to drop {len(tables)} table(s)/view(s)")
+    logger.info("=" * 80)
+
+    success_count = 0
+    failed_count = 0
+
+    for table in tables:
+        success = drop_table_or_view(
+            connection,
+            table["schema"],
+            table["name"],
+            table["type"],
+            catalog,
+            dry_run,
+        )
+        if success:
+            success_count += 1
+        else:
+            failed_count += 1
+
+    logger.info("=" * 80)
+    logger.info(f"Drop summary: {success_count} successful, {failed_count} failed")
+    logger.info("=" * 80)
+
+    return {
+        "total": len(tables),
+        "success": success_count,
+        "failed": failed_count,
+    }
+
+
+def main():
+    """Main entry point for the script."""
+    parser = argparse.ArgumentParser(
+        description="Drop tables and views in a Dune schema via Trino API",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Dry run - drop all dev tables (DUNE_TEAM_NAME__tmp_* pattern)
+  python scripts/drop_tables.py
+
+  # Execute drop for dev tables
+  python scripts/drop_tables.py --execute
+
+  # Drop specific dev table (dry run)
+  python scripts/drop_tables.py --table my_table --schema dune__tmp_jeff
+
+  # Drop specific dev table (execute)
+  python scripts/drop_tables.py --table my_table --schema dune__tmp_jeff --execute
+
+  # Drop specific prod table (dry run - REQUIRES --schema AND --table)
+  python scripts/drop_tables.py --target prod --schema dune --table my_table
+
+  # Drop specific prod table (execute - REQUIRES CONFIRMATION)
+  python scripts/drop_tables.py --target prod --schema dune --table my_table --execute
+        """,
+    )
+
+    # Get default schema pattern from environment
+    dune_team_name = os.getenv("DUNE_TEAM_NAME", "dune")
+    default_dev_pattern = f"{dune_team_name}__tmp_%"
+    default_prod_schema = dune_team_name
+
+    parser.add_argument(
+        "--target",
+        type=str,
+        choices=["dev", "prod"],
+        default="dev",
+        help="Target environment: 'dev' (default, uses __tmp_ pattern) or 'prod' (production schema)",
+    )
+
+    parser.add_argument(
+        "--schema",
+        type=str,
+        default=None,
+        help="Schema name or pattern (overrides --target default)",
+    )
+
+    parser.add_argument(
+        "--table",
+        type=str,
+        default=None,
+        help="Specific table or view name to drop (requires --schema to be exact schema name)",
+    )
+
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Execute the drop operations (default is dry-run mode)",
+    )
+
+    parser.add_argument(
+        "--api-key",
+        type=str,
+        default=None,
+        help="Dune API key (defaults to DUNE_API_KEY env var)",
+    )
+
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Enable verbose (debug) logging",
+    )
+
+    args = parser.parse_args()
+
+    # Set logging level based on verbose flag
+    if args.verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+        logger.setLevel(logging.DEBUG)
+
+    # Determine dry run mode
+    dry_run = not args.execute
+
+    # Determine schema/pattern to use and prod status
+    is_prod = args.target == "prod"
+    
+    if args.schema:
+        schema_or_pattern = args.schema
+        use_pattern = not args.table  # If specific table, don't use pattern matching
+    else:
+        # Use target to determine schema
+        if args.target == "prod":
+            schema_or_pattern = default_prod_schema
+            use_pattern = False  # Prod is exact schema, not a pattern
+        else:  # dev
+            schema_or_pattern = default_dev_pattern
+            use_pattern = True
+
+    # Validation
+    if args.table and not args.schema:
+        logger.error("Error: --table requires --schema to be specified")
+        return 1
+    
+    # Production safety: require specific table/view
+    if is_prod and (not args.schema or not args.table):
+        logger.error("=" * 80)
+        logger.error("Error: Production drops require BOTH --schema AND --table")
+        logger.error("=" * 80)
+        logger.error("For safety, you can only drop one specific table/view at a time in prod.")
+        logger.error("You must specify:")
+        logger.error("  --schema SCHEMA_NAME")
+        logger.error("  --table TABLE_NAME")
+        logger.error("")
+        logger.error("Example:")
+        logger.error(f"  python scripts/drop_tables.py --target prod --schema {default_prod_schema} --table my_table --execute")
+        logger.error("=" * 80)
+        return 1
+
+    # Display mode
+    if dry_run:
+        logger.warning("=" * 80)
+        logger.warning("DRY RUN MODE - No operations will be executed")
+        logger.warning("To execute operations, add the --execute flag")
+        logger.warning("=" * 80)
+
+    # Display target info
+    target_label = f"{'PROD' if is_prod else 'DEV'}"
+    if args.table:
+        logger.info(f"Target [{target_label}]: Specific table '{args.table}' in schema '{args.schema}'")
+    elif use_pattern:
+        logger.info(f"Target [{target_label}]: All tables matching schema pattern '{schema_or_pattern}'")
+    else:
+        logger.info(f"Target [{target_label}]: All tables in schema '{schema_or_pattern}'")
+
+    # Execute
+    try:
+        # Create connection
+        dune_conn = DuneTrinoConnection(api_key=args.api_key)
+        connection = dune_conn.connect()
+
+        # Get tables to drop
+        if args.table:
+            # Drop specific table
+            tables = list_specific_table(
+                connection,
+                args.schema,
+                args.table,
+                catalog="dune",
+            )
+            if not tables:
+                logger.warning(f"Table '{args.table}' not found in schema '{args.schema}'")
+                dune_conn.close()
+                return 0
+        elif use_pattern:
+            # Drop by pattern
+            tables = list_tables_by_pattern(
+                connection,
+                schema_or_pattern,
+                catalog="dune",
+            )
+        else:
+            # Drop all in specific schema (treat as exact match pattern)
+            tables = list_tables_by_pattern(
+                connection,
+                schema_or_pattern,
+                catalog="dune",
+            )
+
+        # Production safety check: require confirmation before dropping
+        if is_prod and not dry_run and tables:
+            logger.warning("")
+            logger.warning("=" * 80)
+            logger.warning("⚠️  PRODUCTION DROP WARNING ⚠️")
+            logger.warning("=" * 80)
+            logger.warning(f"You are about to DROP {len(tables)} table(s)/view(s) from PRODUCTION schema(s)!")
+            logger.warning(f"Schema: {schema_or_pattern}")
+            logger.warning("=" * 80)
+            logger.warning("")
+            
+            # Show first 10 tables as preview
+            preview_count = min(10, len(tables))
+            logger.warning(f"Preview of tables to be dropped (showing {preview_count} of {len(tables)}):")
+            for i, table in enumerate(tables[:preview_count]):
+                logger.warning(f"  {i+1}. {table['schema']}.{table['name']} ({table['type']})")
+            if len(tables) > preview_count:
+                logger.warning(f"  ... and {len(tables) - preview_count} more table(s)")
+            logger.warning("")
+            
+            # Get user confirmation
+            try:
+                response = input("Are you sure you want to proceed? Type 'yes' to confirm: ").strip().lower()
+                if response != "yes":
+                    logger.info("Operation cancelled by user.")
+                    dune_conn.close()
+                    return 0
+                logger.info("Confirmed. Proceeding with drop operations...")
+            except (KeyboardInterrupt, EOFError):
+                logger.info("\nOperation cancelled by user.")
+                dune_conn.close()
+                return 0
+
+        # Drop the tables
+        summary = drop_tables(
+            connection,
+            tables,
+            catalog="dune",
+            dry_run=dry_run,
+        )
+
+        if dry_run:
+            logger.info("")
+            logger.info("=" * 80)
+            logger.info("DRY RUN COMPLETE")
+            logger.info("Above are the DROP commands that would be executed.")
+            logger.info("Use --execute flag to actually drop the tables/views.")
+            logger.info("=" * 80)
+
+        # Close connection
+        dune_conn.close()
+
+        return 0
+
+    except Exception as e:
+        logger.error(f"Failed to complete operation: {e}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+

--- a/scripts/drop_tables.py
+++ b/scripts/drop_tables.py
@@ -493,6 +493,7 @@ Examples:
         logger.info(f"Target [{target_label}]: All tables in schema '{schema_or_pattern}'")
 
     # Execute
+    dune_conn = None
     try:
         # Create connection
         dune_conn = DuneTrinoConnection(api_key=args.api_key)
@@ -509,7 +510,6 @@ Examples:
             )
             if not tables:
                 logger.warning(f"Table '{args.table}' not found in schema '{args.schema}'")
-                dune_conn.close()
                 return 0
         elif use_pattern:
             # Drop by pattern
@@ -551,12 +551,10 @@ Examples:
                 response = input("Are you sure you want to proceed? Type 'yes' to confirm: ").strip().lower()
                 if response != "yes":
                     logger.info("Operation cancelled by user.")
-                    dune_conn.close()
                     return 0
                 logger.info("Confirmed. Proceeding with drop operations...")
             except (KeyboardInterrupt, EOFError):
                 logger.info("\nOperation cancelled by user.")
-                dune_conn.close()
                 return 0
 
         # Drop the tables
@@ -575,14 +573,15 @@ Examples:
             logger.info("Use --execute flag to actually drop the tables/views.")
             logger.info("=" * 80)
 
-        # Close connection
-        dune_conn.close()
-
         return 0
 
     except Exception as e:
         logger.error(f"Failed to complete operation: {e}")
         return 1
+    finally:
+        # Ensure connection is always closed, even if an exception occurs
+        if dune_conn is not None:
+            dune_conn.close()
 
 
 if __name__ == "__main__":

--- a/scripts/drop_tables.py
+++ b/scripts/drop_tables.py
@@ -163,6 +163,65 @@ def list_tables_by_pattern(
         cursor.close()
 
 
+def list_tables_by_schema(
+    connection: trino.dbapi.Connection,
+    schema: str,
+    catalog: str = "dune",
+) -> list:
+    """
+    List all tables in a specific schema using exact equality match.
+
+    Args:
+        connection: Active Trino connection
+        schema: Exact schema name (no pattern matching)
+        catalog: Catalog name (default: 'dune')
+
+    Returns:
+        list: List of dicts with schema, table name, and type
+    """
+    cursor = connection.cursor()
+
+    # Use parameterized query with exact equality (not LIKE)
+    query = """
+        select
+            table_schema
+            , table_name
+            , table_type
+        from
+            dune.information_schema.tables
+        where
+            table_catalog = ?
+            and table_schema = ?
+        order by
+            table_schema
+            , table_name
+    """
+
+    logger.info(f"Querying tables in schema: {schema}")
+    logger.debug(f"Query: {query}")
+    logger.debug(f"Parameters: catalog={catalog}, schema={schema}")
+
+    try:
+        cursor.execute(query, (catalog, schema))
+        results = cursor.fetchall()
+
+        tables = []
+        for row in results:
+            schema_name, table_name, table_type = row
+            tables.append({
+                "schema": schema_name,
+                "name": table_name,
+                "type": table_type,
+            })
+
+        return tables
+    except Exception as e:
+        logger.error(f"Error querying tables: {e}")
+        raise
+    finally:
+        cursor.close()
+
+
 def list_specific_table(
     connection: trino.dbapi.Connection,
     schema: str,
@@ -512,15 +571,15 @@ Examples:
                 logger.warning(f"Table '{args.table}' not found in schema '{args.schema}'")
                 return 0
         elif use_pattern:
-            # Drop by pattern
+            # Drop by pattern (uses SQL LIKE with wildcards)
             tables = list_tables_by_pattern(
                 connection,
                 schema_or_pattern,
                 catalog="dune",
             )
         else:
-            # Drop all in specific schema (treat as exact match pattern)
-            tables = list_tables_by_pattern(
+            # Drop all in specific schema (uses exact equality match)
+            tables = list_tables_by_schema(
                 connection,
                 schema_or_pattern,
                 catalog="dune",

--- a/uv.lock
+++ b/uv.lock
@@ -292,12 +292,14 @@ source = { virtual = "." }
 dependencies = [
     { name = "dbt-core" },
     { name = "dbt-trino" },
+    { name = "trino" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "dbt-core", specifier = ">=1.10.13" },
     { name = "dbt-trino", specifier = ">=1.9.3" },
+    { name = "trino", specifier = ">=0.329.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `scripts/drop_tables.py` to drop tables/views via Trino with dev pattern support and strict prod safeguards, updates docs, and adds `trino` dependency.
> 
> - **Scripts**:
>   - `scripts/drop_tables.py`: Utility to drop tables/views via Trino.
>     - Supports schema pattern matching for dev (e.g., `{team}__tmp_%`) and exact drops.
>     - Prod-only safety: requires `--schema` + `--table` and interactive confirmation.
>     - Dry-run by default; verbose mode; uses `INFORMATION_SCHEMA.TABLES` and safe identifier quoting.
> - **Docs**:
>   - Add `scripts/README.md` with usage, arguments, examples, and output.
>   - Update root `README.md` to include `scripts/` in project structure and link to script docs.
> - **Dependencies**:
>   - Add runtime dependency `trino` in `pyproject.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60fbf8a5b879001b964ebe88a71b4260b583afcd. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->