### PR TITLE
init global post hooks for table maintenance

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -34,3 +34,6 @@ models:
     +materialized: view       # fallback default, materialized should be overriden in model specific configs
     +view_security: invoker   # required security setting for views
     +on_table_exists: replace # dunesql hive metastore does *not* allow rename of table, meaning standard dbt table operations won't work (drop temp table, create temp table, rename existing table to backup, rename temp to final, drop backup)
+    +post-hook:
+      - sql: "{{ optimize_table(this, model.config.materialized) }}"
+        transaction: true

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -37,3 +37,5 @@ models:
     +post-hook:
       - sql: "{{ optimize_table(this, model.config.materialized) }}"
         transaction: true
+      - sql: "{{ vacuum_table(this, model.config.materialized) }}"
+        transaction: true

--- a/macros/dune_dbt_overrides/optimize_table.sql
+++ b/macros/dune_dbt_overrides/optimize_table.sql
@@ -1,0 +1,5 @@
+{% macro optimize_table(this, materialization) %}
+{%- if target.name == 'prod' and materialization in ('table', 'incremental') -%}
+    alter table {{this}} execute optimize
+{%- endif -%}
+{%- endmacro -%}

--- a/macros/dune_dbt_overrides/vacuum_table.sql
+++ b/macros/dune_dbt_overrides/vacuum_table.sql
@@ -1,0 +1,5 @@
+{% macro vacuum_table(this, materialization) %}
+{%- if target.name == 'prod' and materialization in ('table', 'incremental') -%}
+    call delta.system.vacuum('{{ this.schema }}', '{{ this.name }}', '7d')
+{%- endif -%}
+{%- endmacro -%}

--- a/macros/dune_dbt_overrides/vacuum_table.sql
+++ b/macros/dune_dbt_overrides/vacuum_table.sql
@@ -1,5 +1,5 @@
 {% macro vacuum_table(this, materialization) %}
 {%- if target.name == 'prod' and materialization in ('table', 'incremental') -%}
-    call delta.system.vacuum('{{ this.schema }}', '{{ this.name }}', '7d')
+    call dune.system.vacuum('{{ this.schema }}', '{{ this.name }}', '7d')
 {%- endif -%}
 {%- endmacro -%}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds global post-hooks to run optimize and vacuum for table/incremental models in prod.
> 
> - **dbt config (`dbt_project.yml`)**:
>   - Add `+post-hook` for all `dbt_template` models to run `optimize_table` and `vacuum_table`.
> - **Macros**:
>   - `macros/dune_dbt_overrides/optimize_table.sql`: executes `alter table ... optimize` when `target.name == 'prod'` and materialization is `table` or `incremental`.
>   - `macros/dune_dbt_overrides/vacuum_table.sql`: calls `delta.system.vacuum(schema, name, '7d')` under the same conditions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b79566b8742e44bbcbfe458d459343c41d0934f5. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->