### PR TITLE
CUR2-985 remove project-level config for forced replace on table creation

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -33,7 +33,6 @@ models:
     # Config indicated by + and applies to all files under models/templates/
     +materialized: view       # fallback default, materialized should be overriden in model specific configs
     +view_security: invoker   # required security setting for views
-    +on_table_exists: replace # dunesql hive metastore does *not* allow rename of table, meaning standard dbt table operations won't work (drop temp table, create temp table, rename existing table to backup, rename temp to final, drop backup)
     +post-hook:
       - sql: "{{ optimize_table(this, model.config.materialized) }}"
         transaction: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes the project-level `+on_table_exists: replace` setting from `dbt_project.yml` to stop forcing table replacement.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d66f1fe3fb95406174164656589127241405fa5. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->