### PR TITLE
update docs on `create or replace` table strategy

### DIFF
--- a/docs/dbt-best-practices.md
+++ b/docs/dbt-best-practices.md
@@ -275,7 +275,6 @@ where
 
 Set globally in `dbt_project.yml`, do not override:
 - `view_security: invoker` - Required for Dune views
-- `on_table_exists: replace` - Required due to Hive metastore limitations
 - `require_certificate_validation: true` - Security requirement
 
 ## See Also


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes the `on_table_exists: replace` config from defaults and adds a troubleshooting section for DELTA_LAKE_BAD_WRITE during full refresh with manual drop instructions and prevention tips.
> 
> - **Docs**
>   - **Best Practices (`docs/dbt-best-practices.md`)**: Remove `on_table_exists: replace` from Configuration Defaults.
>   - **Troubleshooting (`docs/troubleshooting.md`)**:
>     - Add section: handling full refresh failures with `DELTA_LAKE_BAD_WRITE` when using `on_table_exists: replace` and schema changes.
>     - Provide solutions: manually drop table (script or Trino SQL) before full refresh.
>     - Add prevention guidance: prefer default temp table strategy; use `replace` only for specific cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35a191ae7f2983779e506360fcf577982e4b09f4. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->