### PR TITLE
DWH-526: Fix datashare meta time_start parse-time freeze

### DIFF
--- a/docs/dune-datashares.md
+++ b/docs/dune-datashares.md
@@ -37,8 +37,8 @@ Views are skipped.
 Add `meta.datashare` to a `table` or `incremental` model:
 
 ```sql
-{%- set incremental_time_start = "current_date - interval '1' day" -%}
-{%- set full_refresh_time_start = "current_date - interval '2' day" -%}
+{%- set time_start_incremental = "current_date - interval '1' day" -%}
+{%- set time_start = "current_date - interval '2' day" -%}
 {%- set time_end = "current_date + interval '1' day" -%}
 
 {{ config(
@@ -50,8 +50,8 @@ Add `meta.datashare` to a `table` or `incremental` model:
         "datashare": {
             "enabled": true,
             "time_column": "block_date",
-            "time_start": full_refresh_time_start,
-            "time_start_incremental": incremental_time_start,
+            "time_start": time_start,
+            "time_start_incremental": time_start_incremental,
             "time_end": time_end
         }
     }

--- a/docs/dune-datashares.md
+++ b/docs/dune-datashares.md
@@ -37,6 +37,10 @@ Views are skipped.
 Add `meta.datashare` to a `table` or `incremental` model:
 
 ```sql
+{%- set incremental_time_start = "current_date - interval '1' day" -%}
+{%- set full_refresh_time_start = "current_date - interval '2' day" -%}
+{%- set time_end = "current_date + interval '1' day" -%}
+
 {{ config(
     alias = 'my_datashared_model'
     , materialized = 'incremental'
@@ -46,9 +50,9 @@ Add `meta.datashare` to a `table` or `incremental` model:
         "datashare": {
             "enabled": true,
             "time_column": "block_date",
-            "time_start": "current_date - interval '2' day",
-            "time_start_incremental": "current_date - interval '1' day",
-            "time_end": "current_date + interval '1' day"
+            "time_start": full_refresh_time_start,
+            "time_start_incremental": incremental_time_start,
+            "time_end": time_end
         }
     }
 ) }}

--- a/docs/dune-datashares.md
+++ b/docs/dune-datashares.md
@@ -37,9 +37,6 @@ Views are skipped.
 Add `meta.datashare` to a `table` or `incremental` model:
 
 ```sql
-{% set time_start = "current_date - interval '1' day" if is_incremental() else "current_date - interval '2' day" %}
-{% set time_end = "current_date + interval '1' day" %}
-
 {{ config(
     alias = 'my_datashared_model'
     , materialized = 'incremental'
@@ -49,8 +46,9 @@ Add `meta.datashare` to a `table` or `incremental` model:
         "datashare": {
             "enabled": true,
             "time_column": "block_date",
-            "time_start": time_start,
-            "time_end": time_end
+            "time_start": "current_date - interval '2' day",
+            "time_start_incremental": "current_date - interval '1' day",
+            "time_end": "current_date + interval '1' day"
         }
     }
 ) }}
@@ -60,6 +58,17 @@ select ...
 
 The included example model in this repo follows this pattern.
 
+### Why Two time_start Values
+
+The `meta` dict is captured by dbt at **parse time**, before any adapter state is known. `is_incremental()` always returns `false` during parsing, so a `{% set time_start = "..." if is_incremental() else "..." %}` preamble (as used in older examples and upstream docs) silently freezes the value to the `else` branch on every run.
+
+To actually vary the sync window by run type, provide two static expressions in `meta.datashare`:
+
+- `time_start` — used on **full-refresh** syncs (first run, `--full-refresh`, fingerprint/stamp change)
+- `time_start_incremental` — used on **normal incremental** syncs (optional; falls back to `time_start` if omitted)
+
+The post-hook macro evaluates `is_incremental()` at execution time and picks the correct value.
+
 ## Configuration Reference
 
 All datashare config lives under `meta.datashare` in the model `config()` block.
@@ -68,11 +77,12 @@ All datashare config lives under `meta.datashare` in the model `config()` block.
 | --- | --- | --- | --- |
 | `enabled` | Yes | `boolean` | Must be `true` to trigger sync. |
 | `time_column` | Yes | `string` | Column used to define the sync window. |
-| `time_start` | Yes | `string` | SQL expression for the start of the sync window. |
+| `time_start` | Yes | `string` | SQL expression for the start of the full-refresh sync window. |
+| `time_start_incremental` | No | `string` | SQL expression for incremental runs. Falls back to `time_start` if omitted. |
 | `time_end` | No | `string` | SQL expression for the end of the sync window. Defaults to `now()`. |
 | `unique_key_columns` | No | `list[string]` | Row identity columns. Falls back to the model `unique_key` if omitted. |
 
-`time_start` and `time_end` are SQL expressions, not literal timestamps. The macro wraps them in `CAST(... AS VARCHAR)` before calling the table procedure.
+All time expressions are SQL, not literal timestamps. The macro wraps them in `CAST(... AS VARCHAR)` before calling the table procedure.
 
 Keep the sync window aligned with the `time_column` granularity. For example, if `time_column` is a `date`, use date-based expressions like `current_date - interval '1' day`, not hour-based timestamp windows.
 

--- a/macros/dune_dbt_overrides/datashare_table_sync_post_hook.sql
+++ b/macros/dune_dbt_overrides/datashare_table_sync_post_hook.sql
@@ -70,12 +70,23 @@ ALTER TABLE {{ catalog_name }}.{{ schema_name }}.{{ table_name }} EXECUTE datash
         {{ log('Skipping datashare sync for ' ~ this.schema ~ '.' ~ this.identifier ~ ': datashare post-hook only runs on the prod target.', info=True) }}
         {{ return('') }}
     {%- endif -%}
+    {#- Resolve time_start at execution time. meta.datashare is frozen at parse
+        time and is_incremental() always returns false during parsing, so the
+        picker must live here. meta.datashare.time_start_incremental is optional
+        and falls back to meta.datashare.time_start. -#}
+    {%- set meta = model.config.get('meta', {}) -%}
+    {%- set datashare = meta.get('datashare') if meta is mapping else none -%}
+    {%- set resolved_time_start = none -%}
+    {%- if datashare is mapping and is_incremental() -%}
+        {%- set resolved_time_start = datashare.get('time_start_incremental') -%}
+    {%- endif -%}
     {{ return(_datashare_table_sync_sql(
         schema_name=this.schema,
         table_name=this.identifier,
-        meta=model.config.get('meta', {}),
+        meta=meta,
         materialized=model.config.materialized,
         unique_key=model.config.get('unique_key'),
+        time_start=resolved_time_start,
         full_refresh=(not is_incremental())
     ) or '') }}
 {%- endmacro -%}
@@ -109,13 +120,25 @@ ALTER TABLE {{ catalog_name }}.{{ schema_name }}.{{ table_name }} EXECUTE datash
     {%- set table_name = node.alias if node.alias is not none else node.name -%}
     {%- set is_full_refresh = materialized == 'table' or full_refresh is sameas true -%}
 
+    {#- Mirror the post-hook picker: when running an incremental sync and no
+        explicit time_start was passed, prefer meta.datashare.time_start_incremental
+        if set. Falls back to meta.datashare.time_start otherwise. -#}
+    {%- set resolved_time_start = time_start -%}
+    {%- if resolved_time_start is none and not is_full_refresh -%}
+        {%- set meta = node_config.get('meta', {}) -%}
+        {%- set datashare = meta.get('datashare') if meta is mapping else none -%}
+        {%- if datashare is mapping -%}
+            {%- set resolved_time_start = datashare.get('time_start_incremental') -%}
+        {%- endif -%}
+    {%- endif -%}
+
     {%- set sql = _datashare_table_sync_sql(
         schema_name=node.schema,
         table_name=table_name,
         meta=node_config.get('meta', {}),
         materialized=materialized,
         unique_key=node_config.get('unique_key'),
-        time_start=time_start,
+        time_start=resolved_time_start,
         time_end=time_end,
         full_refresh=is_full_refresh,
         catalog_name=node.database or target.database

--- a/models/templates/dbt_template_datashare_incremental_model.sql
+++ b/models/templates/dbt_template_datashare_incremental_model.sql
@@ -1,5 +1,5 @@
-{%- set incremental_time_start = "current_date - interval '1' day" -%}
-{%- set full_refresh_time_start = "current_date - interval '2' day" -%}
+{%- set time_start_incremental = "current_date - interval '1' day" -%}
+{%- set time_start = "current_date - interval '2' day" -%}
 {%- set time_end = "current_date + interval '1' day" -%}
 
 {{ config(
@@ -7,7 +7,7 @@
     , materialized = 'incremental'
     , incremental_strategy = 'merge'
     , unique_key = ['block_number', 'block_date']
-    , incremental_predicates = ["DBT_INTERNAL_DEST.block_date >= " ~ incremental_time_start]
+    , incremental_predicates = ["DBT_INTERNAL_DEST.block_date >= " ~ time_start_incremental]
     , meta = {
         "dune": {
             "public": false
@@ -15,8 +15,8 @@
         "datashare": {
             "enabled": true,
             "time_column": "block_date",
-            "time_start": full_refresh_time_start,
-            "time_start_incremental": incremental_time_start,
+            "time_start": time_start,
+            "time_start_incremental": time_start_incremental,
             "time_end": time_end
         }
     }
@@ -30,6 +30,6 @@ select
     , block_date
     , count(*) as total_tx_per_block
 from {{ source('ethereum', 'transactions') }}
-where block_date >= {{ incremental_time_start if is_incremental() else full_refresh_time_start }}
+where block_date >= {{ time_start_incremental if is_incremental() else time_start }}
   and block_date < {{ time_end }}
 group by 1, 2

--- a/models/templates/dbt_template_datashare_incremental_model.sql
+++ b/models/templates/dbt_template_datashare_incremental_model.sql
@@ -1,12 +1,3 @@
-{#
-    Window expressions are static SQL strings, `{% set %}` so they can be reused
-    in the config meta (captured at parse time) AND in the SQL body (rendered at
-    execution time).
-
-    Do NOT make these values depend on is_incremental() - the config() meta dict
-    is frozen at parse time, when is_incremental() always returns false. The
-    post-hook picks between time_start / time_start_incremental at execution time.
-#}
 {%- set incremental_time_start = "current_date - interval '1' day" -%}
 {%- set full_refresh_time_start = "current_date - interval '2' day" -%}
 {%- set time_end = "current_date + interval '1' day" -%}

--- a/models/templates/dbt_template_datashare_incremental_model.sql
+++ b/models/templates/dbt_template_datashare_incremental_model.sql
@@ -1,12 +1,22 @@
-{% set time_start = "current_date - interval '1' day" if is_incremental() else "current_date - interval '2' day" %}
-{% set time_end = "current_date + interval '1' day" %}
+{#
+    Window expressions are static SQL strings, `{% set %}` so they can be reused
+    in the config meta (captured at parse time) AND in the SQL body (rendered at
+    execution time).
+
+    Do NOT make these values depend on is_incremental() - the config() meta dict
+    is frozen at parse time, when is_incremental() always returns false. The
+    post-hook picks between time_start / time_start_incremental at execution time.
+#}
+{%- set incremental_time_start = "current_date - interval '1' day" -%}
+{%- set full_refresh_time_start = "current_date - interval '2' day" -%}
+{%- set time_end = "current_date + interval '1' day" -%}
 
 {{ config(
     alias = 'dbt_template_datashare_incremental_model'
     , materialized = 'incremental'
     , incremental_strategy = 'merge'
     , unique_key = ['block_number', 'block_date']
-    , incremental_predicates = ["DBT_INTERNAL_DEST.block_date >= current_date - interval '1' day"]
+    , incremental_predicates = ["DBT_INTERNAL_DEST.block_date >= " ~ incremental_time_start]
     , meta = {
         "dune": {
             "public": false
@@ -14,7 +24,8 @@
         "datashare": {
             "enabled": true,
             "time_column": "block_date",
-            "time_start": time_start,
+            "time_start": full_refresh_time_start,
+            "time_start_incremental": incremental_time_start,
             "time_end": time_end
         }
     }
@@ -28,6 +39,6 @@ select
     , block_date
     , count(*) as total_tx_per_block
 from {{ source('ethereum', 'transactions') }}
-where block_date >= {{ time_start }}
+where block_date >= {{ incremental_time_start if is_incremental() else full_refresh_time_start }}
   and block_date < {{ time_end }}
 group by 1, 2


### PR DESCRIPTION
is_incremental() inside config(meta=...) always resolves to false because dbt captures config at parse time, before adapter state is available. The previous template used {% set time_start = '...' if is_incremental() else '...' %} at the top of the file, which silently froze the sync window to the else branch on every run.

Move the incremental-vs-full-refresh decision into the post-hook macros, which run at execution time. Add optional meta.datashare.time_start_incremental so model authors can declare both windows as static expressions; the macros pick between them based on is_incremental() (post-hook) or the full_refresh flag (run-operation).