### PR TITLE
DWH-591: make datashare cadence/window defaults cost-safe

### DIFF
--- a/.github/workflows/dbt_prod.yml
+++ b/.github/workflows/dbt_prod.yml
@@ -2,8 +2,13 @@ name: dbt prod incremental
 
 on:
   # schedule:
-  #   - cron: '0 * * * *'  # Run every hour at minute 0
-  # NOTE: Schedule is disabled by default. Uncomment when ready to enable hourly production runs.
+  #   - cron: '0 6 * * *'  # Daily at 06:00 UTC. Safe default for date-granularity datashare models.
+  #   # - cron: '0 * * * *'  # Hourly. Only safe if your datashare models use a timestamp
+  #                          # `time_column` with an hour-sized incremental window. See
+  #                          # docs/dune-datashares.md "Cadence and sync windows" — a date
+  #                          # `time_column` with hourly cadence re-reads the full day on
+  #                          # every MERGE (24x cross-region read cost on S3 Export).
+  # NOTE: Schedule is disabled by default. Uncomment one cron above when ready.
   # Check the README.md to make sure you understand the credit costs associated with running dbt.
   workflow_dispatch:  # Allow manual triggers
 

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Runs on every PR. Enforces branch is up-to-date with main, then runs and tests m
 
 ### Production Workflow (Scheduled)
 
-Runs hourly on main branch. Uses state comparison to only full refresh modified models, then runs normal cadence runs.
+Runs on a schedule on main branch (disabled by default; daily cron is the safe default — see [docs/cicd.md](docs/cicd.md) for the daily-vs-hourly cost tradeoff with datashares). Uses state comparison to only full refresh modified models, then runs normal cadence runs.
 
 **Target:** Sets `DBT_TARGET: prod` to write to production schemas (`{team}`)
 

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -59,7 +59,12 @@ uv run dbt test --select modified_model
 **File:** `.github/workflows/dbt_prod.yml`
 **Branch:** `main` only
 
-⚠️ **Note:** The hourly schedule is **disabled by default** in the template. Teams must uncomment the schedule in the workflow file when ready to enable automatic hourly runs.
+⚠️ **Note:** The schedule is **disabled by default** in the template. Teams must uncomment the cron line in the workflow file when ready to enable scheduled runs.
+
+The workflow file offers two cron options:
+
+- **Daily** (`0 6 * * *`) — the safe default. Pairs with the included date-granularity datashare example.
+- **Hourly** (`0 * * * *`) — only safe if every datashare model uses a timestamp `time_column` with an hour-sized incremental window. A date `time_column` with hourly cadence re-reads the full day's partition from the destination on every MERGE, which is 24x the cross-region transfer cost on S3 Export targets. See [Cadence and sync windows](dune-datashares.md#cadence-and-sync-windows).
 
 ### What It Does
 
@@ -126,7 +131,7 @@ Runs when:
 
 Runs when:
 
-- Hourly (cron: `'0 * * * *'`) - **disabled by default, must be uncommented**
+- Scheduled cron - **disabled by default, must be uncommented**. The workflow ships with a daily option (`'0 6 * * *'`) and a commented hourly option; see the cost note above before choosing hourly.
 - Manual trigger via GitHub Actions UI
 
 ## Troubleshooting CI Failures

--- a/docs/dune-datashares.md
+++ b/docs/dune-datashares.md
@@ -90,6 +90,55 @@ All time expressions are SQL, not literal timestamps. The macro wraps them in `C
 
 Keep the sync window aligned with the `time_column` granularity. For example, if `time_column` is a `date`, use date-based expressions like `current_date - interval '1' day`, not hour-based timestamp windows.
 
+## Cadence and sync windows
+
+The `time_start_incremental` → `time_end` window and your dbt **run cadence** are not independent knobs. Every incremental sync issues a `MERGE INTO` against the destination table, which re-reads the destination data covered by that window. On **S3 Export** targets where the destination bucket is in a different region from Trino, each run pays cross-region transfer for the entire window.
+
+The cost amplification factor is:
+
+```
+remote_read_multiplier = MERGE read window / run cadence
+```
+
+Examples:
+
+| Cadence | `time_column` | Incremental window         | Multiplier | Notes |
+| ------- | ------------- | -------------------------- | ---------- | ----- |
+| Daily   | `date`        | `interval '1' day`         | 1x         | Safe default. The included example model uses this shape. |
+| Hourly  | `timestamp`   | `interval '2' hour`        | 2x         | Use only when `time_column` is timestamp-granular and the destination is partitioned/prunable on it. |
+| Hourly  | `date`        | `interval '1' day`         | 24x        | **Cost trap.** Every hourly run re-reads the full day's partition from the destination. |
+
+Rules of thumb:
+
+- Date-granularity `time_column` (e.g. `block_date`) → **daily cadence**. Sub-day windows on a date column do nothing useful: the smallest prunable unit is one day.
+- Hourly (or sub-day) cadence → **timestamp** `time_column` AND an hour-sized incremental window. Confirm the destination table is partitioned on that timestamp so MERGE actually prunes.
+- The `time_start` (full-refresh) value can stay wider than `time_start_incremental` — full refreshes are infrequent, the multiplier only applies to incremental cadence.
+
+### Hourly cadence example
+
+```sql
+{%- set time_start_incremental = "current_timestamp - interval '2' hour" -%}
+{%- set time_start = "current_timestamp - interval '1' day" -%}
+{%- set time_end = "current_timestamp" -%}
+
+{{ config(
+    materialized = 'incremental',
+    incremental_strategy = 'merge',
+    unique_key = ['tx_hash'],
+    incremental_predicates = ["DBT_INTERNAL_DEST.block_time >= " ~ time_start_incremental],
+    meta = {
+        "datashare": {
+            "enabled": true,
+            "time_column": "block_time",
+            "time_start": time_start,
+            "time_start_incremental": time_start_incremental,
+            "time_end": time_end
+        }
+    },
+    properties = {"partitioned_by": "ARRAY['date(block_time)']"}
+) }}
+```
+
 ## Full Refresh Behavior
 
 The macro determines `full_refresh` automatically:

--- a/models/templates/dbt_template_datashare_incremental_model.sql
+++ b/models/templates/dbt_template_datashare_incremental_model.sql
@@ -1,3 +1,13 @@
+-- Datashare cadence/window pairing (see docs/dune-datashares.md "Cadence and sync windows").
+--
+-- This example uses a date `time_column` (`block_date`) and is designed for
+-- DAILY cadence. Each incremental run MERGEs the last 1 day of data, which on
+-- S3 Export means re-reading 1 day of the destination partition per run.
+--
+-- If you switch to hourly cadence WITHOUT also switching to a timestamp
+-- `time_column` and an hour-sized window, every hourly run will re-read the
+-- full day from the destination (24x amplification on cross-region S3 buckets).
+-- For hourly freshness, see the "Hourly cadence" example in the docs.
 {%- set time_start_incremental = "current_date - interval '1' day" -%}
 {%- set time_start = "current_date - interval '2' day" -%}
 {%- set time_end = "current_date + interval '1' day" -%}


### PR DESCRIPTION
The included datashare example uses a date `time_column` (block_date) but the workflow guidance pointed at hourly cron. Hourly cadence with a date window causes every MERGE to re-read the full day's partition from the destination — a 24x cross-region read amplification on S3 Export targets.

- Default the commented prod cron to daily (0 6 * * *); keep hourly as a commented alternative with an inline cost warning.
- Document the tradeoff in docs/dune-datashares.md under a new 'Cadence and sync windows' section, with the formula remote_read_multiplier = MERGE read window / run cadence and an hourly-cadence timestamp example.
- Update docs/cicd.md and README.md to match the new daily default and cross-link the cost note.
- Add a leading comment block to the example model explaining the daily-cadence pairing and the hourly trap.