### PR TITLE
Add uv no-build (binary-only)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dbt = "dbt.cli.main:cli"
 [tool.uv]
 package = false
 exclude-newer = "3 days"
+no-build = true
 
 [dependency-groups]
 dev = []


### PR DESCRIPTION
Add uv `no-build = true` (binary-only) to enforce wheels-only installs (block source builds at install time).
