### PR TITLE
fix: guard datashare run-operation against non-prod targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this template will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
-- **Datashare `run-operation` could sync dev schemas**: `datashare_trigger_sync_operation` had no target guard, so running it without `--target prod` registered the dev temp schema (`<team>__tmp_<suffix>`) as a real datashare and shipped it to the destination warehouse. It now raises a clear error outside `prod`, naming the schema it would have registered. `dry_run: true` is still permitted on any target, and `allow_non_prod: true` is available as an explicit override.
+- **Datashare `run-operation` could sync dev schemas**: `datashare_trigger_sync_operation` had no target guard, so running it without `--target prod` registered the dev temp schema (`<team>__tmp_<suffix>`) as a real datashare and shipped it to the destination warehouse. It now raises a clear error outside `prod`, naming the schema it would have registered. `dry_run: true` is still permitted on any target, and `allow_prod_only: false` is available as an explicit override.
 - **Datashare docs omitted `--target prod`**: all `run-operation` examples in `docs/dune-datashares.md` now pass `--target prod`, with a note explaining why it matters.
 
 ## [v1.4.0] - 2026-04-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this template will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- **Datashare `run-operation` could sync dev schemas**: `datashare_trigger_sync_operation` had no target guard, so running it without `--target prod` registered the dev temp schema (`<team>__tmp_<suffix>`) as a real datashare and shipped it to the destination warehouse. It now raises a clear error outside `prod`, naming the schema it would have registered. `dry_run: true` is still permitted on any target, and `allow_non_prod: true` is available as an explicit override.
+- **Datashare docs omitted `--target prod`**: all `run-operation` examples in `docs/dune-datashares.md` now pass `--target prod`, with a note explaining why it matters.
+
 ## [v1.4.0] - 2026-04-02
 
 ### Added

--- a/docs/dune-datashares.md
+++ b/docs/dune-datashares.md
@@ -202,7 +202,7 @@ full_refresh: true
 
 `model_selector` accepts the model name, alias, fully qualified name, or dbt `unique_id`.
 
-If you need to sync from a non-prod schema deliberately, pass `allow_non_prod: true`. This is not recommended: dev schemas are ephemeral, and once a sync is registered the destination table and view persist under the temp schema name.
+If you need to sync from a non-prod schema deliberately, pass `allow_prod_only: false`. This is not recommended: dev schemas are ephemeral, and once a sync is registered the destination table and view persist under the temp schema name.
 
 ## Monitoring
 

--- a/docs/dune-datashares.md
+++ b/docs/dune-datashares.md
@@ -168,19 +168,23 @@ ALTER TABLE dune.<schema>.<table> EXECUTE datashare(
 
 Use `run-operation` when you want to trigger a sync outside `dbt run`.
 
+**Always pass `--target prod`.** Unlike the post-hook, this path reads the schema straight from the manifest, so on the default `dev` target it would register your temp schema (`<team>__tmp_<suffix>`) as a real datashare and ship it to your destination warehouse. The macro refuses to execute outside `prod` for this reason.
+
 Preview the generated SQL only:
 
 ```bash
-uv run dbt run-operation datashare_trigger_sync_operation --args '
+uv run dbt run-operation datashare_trigger_sync_operation --target prod --args '
 model_selector: dbt_template_datashare_incremental_model
 dry_run: true
 '
 ```
 
+`dry_run: true` is allowed on any target, since it only prints SQL.
+
 Execute a sync:
 
 ```bash
-uv run dbt run-operation datashare_trigger_sync_operation --args '
+uv run dbt run-operation datashare_trigger_sync_operation --target prod --args '
 model_selector: dbt_template_datashare_incremental_model
 time_start: "current_date - interval '\''7'\'' day"
 time_end: "current_date + interval '\''1'\'' day"
@@ -190,13 +194,15 @@ time_end: "current_date + interval '\''1'\'' day"
 Force a full refresh sync:
 
 ```bash
-uv run dbt run-operation datashare_trigger_sync_operation --args '
+uv run dbt run-operation datashare_trigger_sync_operation --target prod --args '
 model_selector: dbt_template_datashare_incremental_model
 full_refresh: true
 '
 ```
 
 `model_selector` accepts the model name, alias, fully qualified name, or dbt `unique_id`.
+
+If you need to sync from a non-prod schema deliberately, pass `allow_non_prod: true`. This is not recommended: dev schemas are ephemeral, and once a sync is registered the destination table and view persist under the temp schema name.
 
 ## Monitoring
 

--- a/macros/dune_dbt_overrides/datashare_table_sync_post_hook.sql
+++ b/macros/dune_dbt_overrides/datashare_table_sync_post_hook.sql
@@ -165,20 +165,20 @@ ALTER TABLE {{ catalog_name }}.{{ schema_name }}.{{ table_name }} EXECUTE datash
     {{ return(matches[0]) }}
 {%- endmacro -%}
 
-{% macro datashare_trigger_sync_operation(model_selector, time_start=None, time_end=None, dry_run=False, full_refresh=False, allow_non_prod=False) %}
+{% macro datashare_trigger_sync_operation(model_selector, time_start=None, time_end=None, dry_run=False, full_refresh=False, allow_prod_only=True) %}
     {%- set node = _datashare_resolve_model_node(model_selector) -%}
     {%- set node_config = node.config if node.config is mapping else {} -%}
     {%- set materialized = node_config.get('materialized', 'view') -%}
     {%- set table_name = node.alias if node.alias is not none else node.name -%}
     {%- set is_full_refresh = materialized == 'table' or full_refresh is sameas true -%}
     {%- set is_dry_run = dry_run is sameas true or (dry_run is string and dry_run | lower in ['true', '1', 'yes', 'y']) -%}
-    {%- set is_allow_non_prod = allow_non_prod is sameas true or (allow_non_prod is string and allow_non_prod | lower in ['true', '1', 'yes', 'y']) -%}
+    {%- set allow_prod_only = false if (allow_prod_only is sameas false or (allow_prod_only is string and allow_prod_only | lower in ['false', '0', 'no', 'n'])) else true -%}
 
     {#- The post-hook guards on target, but this path resolves the schema straight
         from the manifest, so on a dev target it registers the temp schema as a
         real datashare and ships it to the destination. Fail loudly rather than
         skip silently: the caller explicitly asked for a sync. -#}
-    {%- if target.name != 'prod' and not is_dry_run and not is_allow_non_prod -%}
+    {%- if target.name != 'prod' and allow_prod_only and not is_dry_run -%}
         {{ exceptions.raise_compiler_error(
             "Refusing datashare sync for '" ~ model_selector ~ "' on target '" ~ target.name
             ~ "': the source schema would be '" ~ node.schema ~ "'. Datashare syncs must run against prod."

--- a/macros/dune_dbt_overrides/datashare_table_sync_post_hook.sql
+++ b/macros/dune_dbt_overrides/datashare_table_sync_post_hook.sql
@@ -165,12 +165,26 @@ ALTER TABLE {{ catalog_name }}.{{ schema_name }}.{{ table_name }} EXECUTE datash
     {{ return(matches[0]) }}
 {%- endmacro -%}
 
-{% macro datashare_trigger_sync_operation(model_selector, time_start=None, time_end=None, dry_run=False, full_refresh=False) %}
+{% macro datashare_trigger_sync_operation(model_selector, time_start=None, time_end=None, dry_run=False, full_refresh=False, allow_non_prod=False) %}
     {%- set node = _datashare_resolve_model_node(model_selector) -%}
     {%- set node_config = node.config if node.config is mapping else {} -%}
     {%- set materialized = node_config.get('materialized', 'view') -%}
     {%- set table_name = node.alias if node.alias is not none else node.name -%}
     {%- set is_full_refresh = materialized == 'table' or full_refresh is sameas true -%}
+    {%- set is_dry_run = dry_run is sameas true or (dry_run is string and dry_run | lower in ['true', '1', 'yes', 'y']) -%}
+    {%- set is_allow_non_prod = allow_non_prod is sameas true or (allow_non_prod is string and allow_non_prod | lower in ['true', '1', 'yes', 'y']) -%}
+
+    {#- The post-hook guards on target, but this path resolves the schema straight
+        from the manifest, so on a dev target it registers the temp schema as a
+        real datashare and ships it to the destination. Fail loudly rather than
+        skip silently: the caller explicitly asked for a sync. -#}
+    {%- if target.name != 'prod' and not is_dry_run and not is_allow_non_prod -%}
+        {{ exceptions.raise_compiler_error(
+            "Refusing datashare sync for '" ~ model_selector ~ "' on target '" ~ target.name
+            ~ "': the source schema would be '" ~ node.schema ~ "'. Datashare syncs must run against prod."
+            ~ " Re-run with --target prod, or pass dry_run: true to preview the SQL."
+        ) }}
+    {%- endif -%}
 
     {#- Mirror the post-hook picker: when running an incremental sync and no
         explicit time_start was passed, prefer meta.datashare.time_start_incremental
@@ -200,7 +214,6 @@ ALTER TABLE {{ catalog_name }}.{{ schema_name }}.{{ table_name }} EXECUTE datash
         {{ exceptions.raise_compiler_error("Cannot sync " ~ node.schema ~ "." ~ table_name ~ ": model must be incremental or table with meta.datashare.enabled = true.") }}
     {%- endif -%}
 
-    {%- set is_dry_run = dry_run is sameas true or (dry_run is string and dry_run | lower in ['true', '1', 'yes', 'y']) -%}
     {%- if not is_dry_run -%}
         {% do run_query(sql) %}
         {{ log('Executed datashare sync for selector ' ~ model_selector, info=True) }}


### PR DESCRIPTION
## Summary

`datashare_trigger_sync_operation` has no target guard. It resolves the source schema straight from the manifest, so on the default `dev` target it registers the temp schema (`<team>__tmp_<suffix>`) as a real datashare and ships it to the destination warehouse. `datashare_trigger_sync()` (the post-hook) already guards on `target.name != 'prod'`; this path never did.

Every `run-operation` example in `docs/dune-datashares.md` omitted `--target prod`, so following the docs verbatim reproduces the bug.

## Impact

Confirmed in production at a customer. Two invocations from their `dbt.log`, neither with `--target prod`:

```
invocation_command: dbt run-operation datashare_trigger_sync_operation --args
  model_selector: staking_balance
target_name: "dev"
→ ALTER TABLE dune.<team>__tmp_<user>.staking_balance EXECUTE datashare(...)
```

This produced destination tables and views named after their dev schema, which they then found in BigQuery. Their post-hook behaved correctly throughout the same run (35 × `Skipping ... only runs on the prod target`).

Two things make it worse than a stray registration:

- `_datashare_active_sync_exists` forces `full_refresh = true` when no registration exists. A dev schema never has one, so the **first** accidental invocation is always the most expensive variant.
- With `full_refresh`, `time_start` resolves to the model's full-backfill window. In the customer's case that shipped a ~2-year window from a dev table.

Dev schemas are also ephemeral, so once the source table is dropped, `EXECUTE delete_datashare` can no longer remove the registration.

## Changes

- `datashare_trigger_sync_operation` raises a compiler error outside `prod`, naming the schema it would have registered.
- `dry_run: true` remains allowed on any target, since it only prints SQL.
- `allow_non_prod: true` added as an explicit override for deliberate use.
- All three `run-operation` examples in `docs/dune-datashares.md` now pass `--target prod`, with a note explaining why.
- CHANGELOG entry.

Raises rather than skips silently: unlike the post-hook, the caller here explicitly asked for a sync, so doing nothing quietly would be its own confusion.

## Test plan

Verified against this branch:

- [x] `run-operation` on `dev` without `dry_run` → fails with `Refusing datashare sync for 'dbt_template_datashare_incremental_model' on target 'dev': the source schema would be 'dune__tmp_'. ...`
- [x] `run-operation` on `dev` with `dry_run: true` → succeeds, prints SQL, executes nothing
- [x] `run-operation --target prod` with `dry_run: true` → unchanged behavior
- [ ] Reviewer: confirm `allow_non_prod: true` is wanted at all — happy to drop it and make the guard absolute

## Follow-ups (not in this PR)

- No server-side validation that a datashare source schema isn't a `__tmp_` schema. A backend guard would protect teams pinned to older macro versions.
- `EXECUTE delete_datashare` requires the source table to exist, leaving unremovable registrations after a dev schema is dropped.
- The public docs page (`api-reference/connectors/dbt/datashares`) describes the guard as *"the template runs this hook only on the `prod` target"* rather than showing it inline. Teams with existing dbt projects copy the YAML and never see the macro. Separate PR to follow in `dune-docs`.

Made with [Cursor](https://cursor.com)