### PR TITLE
fix: scope bulk drops in drop_tables.py to dev schemas

### DIFF
--- a/.github/workflows/scripts_tests.yml
+++ b/.github/workflows/scripts_tests.yml
@@ -1,0 +1,38 @@
+name: Script tests
+
+# Unlike dbt CI, these tests stub out the Trino driver. They consume no Dune
+# credits and need no secrets, so they run on every relevant pull request.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'scripts/**'
+      - 'tests/**'
+      - '.github/workflows/scripts_tests.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'scripts/**'
+      - 'tests/**'
+      - '.github/workflows/scripts_tests.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unittest:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 5
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Run script safety tests
+        # Standard library only, so the runner's system Python is sufficient.
+        run: python3 -m unittest discover tests --verbose

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,8 +12,8 @@ This script connects to the Dune Trino API using the same configuration as dbt a
 - **Target environment** (dev or prod)
   - `dev` (default): Drops all tables matching `{DUNE_TEAM_NAME}__tmp_%` pattern (bulk drops allowed)
   - `prod`: **Only allows dropping ONE specific table/view at a time** (requires `--schema` and `--table`)
-- **Schema pattern matching** (dev only - override with `--schema` for custom patterns)
-- **Specific table/view** (drop a single table or view)
+- **Schema pattern matching** (bulk drops are restricted to `{DUNE_TEAM_NAME}__tmp_` schemas)
+- **Specific table/view** (drop a single table or view from any schema)
 
 The script uses `INFORMATION_SCHEMA.TABLES` to find tables and generates appropriate `DROP TABLE` or `DROP VIEW` commands based on the object type.
 
@@ -22,10 +22,12 @@ The script uses `INFORMATION_SCHEMA.TABLES` to find tables and generates appropr
 - S3 cleanup should be handled separately via scheduled cleanup jobs
 - This script does not clean up S3 data (requires separate AWS access)
 
-**Production Safety**: 
-- Prod drops require BOTH `--schema` AND `--table` (no bulk drops)
-- Interactive confirmation is required before executing prod drops
-- This ensures prod drops are deliberate, specific, and rare
+**Safety model**:
+- Bulk drops (no `--table`) are only permitted against disposable dev schemas, meaning those starting with `{DUNE_TEAM_NAME}__tmp_`
+- The production schema can **never** be bulk-dropped. Production objects must be dropped one at a time with `--table`
+- Any drop touching a schema outside the dev namespace requires interactive confirmation
+- Bulk-dropping some other non-production schema is possible, but requires the explicit `--allow-bulk-outside-dev` flag
+- These rules are enforced against the schema being targeted, **not** against the `--target` flag, so they cannot be bypassed by omitting `--target prod`
 
 ### Prerequisites
 
@@ -78,14 +80,25 @@ python scripts/drop_tables.py --target prod --schema dune --table my_table --exe
 
 #### Drop Specific Schema
 
-Drop all tables in a specific schema (exact match):
+Drop all tables in a specific dev schema:
 
 ```bash
 # Dry run - show what would be dropped
-python scripts/drop_tables.py --schema my_custom_schema
+python scripts/drop_tables.py --schema dune__tmp_pr123
 
 # Execute - actually drop the tables
-python scripts/drop_tables.py --schema my_custom_schema --execute
+python scripts/drop_tables.py --schema dune__tmp_pr123 --execute
+```
+
+⚠️ **`--schema` is a SQL LIKE pattern, not a literal name.** A value such as `%` would match every
+schema the API key can see. Because of this, bulk drops are refused unless every schema the pattern
+resolves to sits inside the `{DUNE_TEAM_NAME}__tmp_` dev namespace.
+
+To bulk-drop a non-production schema outside that namespace, opt in explicitly. This still requires
+interactive confirmation, and still refuses to touch the production schema:
+
+```bash
+python scripts/drop_tables.py --schema scratch_area --allow-bulk-outside-dev --execute
 ```
 
 #### Drop Specific Table/View
@@ -120,6 +133,7 @@ python scripts/drop_tables.py --execute --api-key YOUR_API_KEY_HERE
 | `--schema` | Schema name or pattern (overrides `--target`) | None (uses target default) |
 | `--table` | Specific table/view name (requires `--schema`) | None (drops all) |
 | `--execute` | Execute the drop operations (default is dry-run) | False |
+| `--allow-bulk-outside-dev` | Permit a bulk drop outside the `__tmp_` dev namespace. Never permits bulk-dropping the production schema | False |
 | `--api-key` | Dune API key | `DUNE_API_KEY` env var |
 | `--verbose`, `-v` | Enable verbose (debug) logging | False |
 
@@ -154,8 +168,8 @@ python scripts/drop_tables.py --target prod --schema dune --table my_model
 # Drop specific PROD table (execute - REQUIRES CONFIRMATION)
 python scripts/drop_tables.py --target prod --schema dune --table my_model --execute
 
-# Drop with custom pattern (any dev schema starting with 'test_')
-python scripts/drop_tables.py --schema test_% --execute
+# Bulk drop outside the dev namespace (refused without the opt-in flag)
+python scripts/drop_tables.py --schema test_% --allow-bulk-outside-dev --execute
 
 # Verbose output for debugging
 python scripts/drop_tables.py --verbose
@@ -240,8 +254,9 @@ The script uses the following connection configuration (matching `profiles.yml`)
 
 **Pattern Matching Behavior:**
 - Default pattern `{DUNE_TEAM_NAME}__tmp_%` matches all dev schemas
-- The `%` wildcard matches any characters (including none)
-- You can provide custom patterns with `--schema` (e.g., `test_%`, `staging_%`)
+- The `%` wildcard matches any characters (including none), and `_` matches any single character
+- You can provide custom patterns with `--schema` (e.g., `test_%`, `staging_%`), but a bulk drop is refused unless every schema the pattern resolves to is a `__tmp_` dev schema, or `--allow-bulk-outside-dev` is passed
+- Validation happens against the schemas the pattern actually resolved to, so wildcard behaviour cannot widen the blast radius unnoticed
 
 This approach is particularly useful for:
 - Cleaning up all dev schemas at once (including PR schemas)
@@ -251,7 +266,19 @@ This approach is particularly useful for:
 ### Safety Features
 
 - **Dry run by default**: Prevents accidental deletions
+- **Bulk drops scoped to the dev namespace**: Enforced against the resolved schema rather than the `--target` flag, so it cannot be bypassed by omitting `--target prod`
+- **Production schema can never be bulk-dropped**: Even with `--allow-bulk-outside-dev`
+- **Confirmation outside the dev namespace**: Any drop touching a non-`__tmp_` schema requires typing `yes`
 - **Clear logging**: All DROP commands are displayed before execution
 - **Pattern visibility**: Shows which schemas are matched before dropping
 - **Summary reporting**: Confirms what was dropped and if any failures occurred
 - **Uses `IF EXISTS`**: DROP commands won't fail if table doesn't exist
+
+### Tests
+
+The guards above are covered by regression tests that stub the Trino driver, so they never connect to
+Dune or touch real data. They use only the standard library, so no extra dependencies are needed:
+
+```bash
+uv run python -m unittest discover tests
+```

--- a/scripts/drop_tables.py
+++ b/scripts/drop_tables.py
@@ -8,21 +8,32 @@ as dbt and drops tables and views based on schema pattern or specific table name
 NOTE: Trino's DROP TABLE command only removes the metastore entry, leaving orphaned
 data in S3. S3 cleanup should be handled separately via scheduled cleanup jobs.
 
+Safety model:
+    Bulk drops (no --table) are only permitted against disposable dev schemas,
+    meaning those starting with DUNE_TEAM_NAME__tmp_. Anything else requires
+    either --table for a single object, or an explicit --allow-bulk-outside-dev
+    plus interactive confirmation. The production schema can never be
+    bulk-dropped. Note that --schema is used as a SQL LIKE pattern, so it is
+    validated against the schemas it actually resolves to.
+
 Usage:
     # Dry run - drop all tables matching DUNE_TEAM_NAME__tmp_* pattern
     python scripts/drop_tables.py
 
-    # Dry run - drop all tables in specific schema
-    python scripts/drop_tables.py --schema my_custom_schema
-
-    # Dry run - drop specific table
-    python scripts/drop_tables.py --table my_table_name --schema my_schema
-
     # Actually execute drops
     python scripts/drop_tables.py --execute
 
-    # Execute drop for specific schema
-    python scripts/drop_tables.py --schema my_schema --execute
+    # Dry run - drop all tables in one dev schema
+    python scripts/drop_tables.py --schema my_team__tmp_pr123
+
+    # Dry run - drop a specific table from any schema
+    python scripts/drop_tables.py --table my_table_name --schema my_schema
+
+    # Execute drop of a specific production table (requires confirmation)
+    python scripts/drop_tables.py --target prod --schema my_team --table my_table --execute
+
+    # Deliberately bulk-drop a non-production, non-dev schema
+    python scripts/drop_tables.py --schema scratch_area --allow-bulk-outside-dev --execute
 """
 
 import argparse
@@ -416,6 +427,40 @@ def drop_tables(
     }
 
 
+DEV_SCHEMA_MARKER = "__tmp_"
+
+
+def dev_schema_prefix(team_name: str) -> str:
+    """
+    Return the prefix shared by every disposable dbt dev schema.
+
+    Args:
+        team_name: Value of DUNE_TEAM_NAME
+
+    Returns:
+        str: Prefix such as 'my_team__tmp_'
+    """
+    return f"{team_name}{DEV_SCHEMA_MARKER}"
+
+
+def is_dev_schema(schema: str, team_name: str) -> bool:
+    """
+    Determine whether a schema is a disposable dev schema.
+
+    Compares against the literal prefix rather than reusing the LIKE pattern.
+    In SQL LIKE an underscore matches any single character, so a pattern-based
+    check would treat schemas like 'my_teamXXtmpY' as dev schemas.
+
+    Args:
+        schema: Concrete schema name as returned by information_schema
+        team_name: Value of DUNE_TEAM_NAME
+
+    Returns:
+        bool: True if the schema is a dev schema
+    """
+    return schema.startswith(dev_schema_prefix(team_name))
+
+
 def main():
     """Main entry point for the script."""
     parser = argparse.ArgumentParser(
@@ -434,6 +479,9 @@ Examples:
 
   # Drop specific dev table (execute)
   python scripts/drop_tables.py --table my_table --schema dune__tmp_jeff --execute
+
+  # Bulk drop outside the dev namespace (BLOCKED unless opted in explicitly)
+  python scripts/drop_tables.py --schema scratch_area --allow-bulk-outside-dev --execute
 
   # Drop specific prod table (dry run - REQUIRES --schema AND --table)
   python scripts/drop_tables.py --target prod --schema dune --table my_table
@@ -474,6 +522,16 @@ Examples:
         "--execute",
         action="store_true",
         help="Execute the drop operations (default is dry-run mode)",
+    )
+
+    parser.add_argument(
+        "--allow-bulk-outside-dev",
+        action="store_true",
+        help=(
+            "Permit a bulk drop against schemas outside the "
+            "{DUNE_TEAM_NAME}__tmp_ dev namespace. Requires interactive "
+            "confirmation. The production schema can never be bulk-dropped."
+        ),
     )
 
     parser.add_argument(
@@ -535,6 +593,30 @@ Examples:
         logger.error("=" * 80)
         return 1
 
+    # Bulk safety. The checks above key off --target, so they are bypassed
+    # entirely whenever --schema is supplied. This check keys off the schema
+    # actually being targeted, which is what determines the blast radius.
+    bulk = not args.table
+    dev_prefix = dev_schema_prefix(dune_team_name)
+
+    if bulk and not schema_or_pattern.startswith(dev_prefix) and not args.allow_bulk_outside_dev:
+        logger.error("=" * 80)
+        logger.error("Error: Refusing to bulk-drop outside the dev namespace")
+        logger.error("=" * 80)
+        logger.error(f"Requested schema or pattern: '{schema_or_pattern}'")
+        logger.error(f"Bulk drops are limited to schemas starting with: '{dev_prefix}'")
+        logger.error("")
+        logger.error("--schema is used as a SQL LIKE pattern, so a value such as '%'")
+        logger.error("would otherwise match every schema this API key can see.")
+        logger.error("")
+        logger.error("To drop a single object from any schema:")
+        logger.error(f"  python scripts/drop_tables.py --schema {schema_or_pattern} --table TABLE_NAME --execute")
+        logger.error("")
+        logger.error("To bulk-drop a non-production schema deliberately:")
+        logger.error(f"  python scripts/drop_tables.py --schema {schema_or_pattern} --allow-bulk-outside-dev --execute")
+        logger.error("=" * 80)
+        return 1
+
     # Display mode
     if dry_run:
         logger.warning("=" * 80)
@@ -585,14 +667,43 @@ Examples:
                 catalog="dune",
             )
 
-        # Production safety check: require confirmation before dropping
-        if is_prod and not dry_run and tables:
+        # Safety net against the schemas that were actually resolved, rather
+        # than against the requested pattern. This is the authoritative check:
+        # it holds regardless of how LIKE expanded the pattern.
+        non_dev_schemas = sorted(
+            {t["schema"] for t in tables if not is_dev_schema(t["schema"], dune_team_name)}
+        )
+
+        if bulk and default_prod_schema in non_dev_schemas:
+            logger.error("=" * 80)
+            logger.error("Error: Refusing to bulk-drop the production schema")
+            logger.error("=" * 80)
+            logger.error(f"'{schema_or_pattern}' resolved to production schema '{default_prod_schema}'.")
+            logger.error("Production objects must be dropped one at a time using --table.")
+            logger.error("=" * 80)
+            return 1
+
+        if bulk and non_dev_schemas and not args.allow_bulk_outside_dev:
+            logger.error("=" * 80)
+            logger.error("Error: Pattern resolved to schemas outside the dev namespace")
+            logger.error("=" * 80)
+            logger.error(f"'{schema_or_pattern}' matched these non-dev schema(s):")
+            for schema_name in non_dev_schemas:
+                logger.error(f"  {schema_name}")
+            logger.error("")
+            logger.error("Re-run with --allow-bulk-outside-dev if this is intended.")
+            logger.error("=" * 80)
+            return 1
+
+        # Require confirmation before dropping anything outside the disposable
+        # dev namespace, whether or not --target prod was passed.
+        if non_dev_schemas and not dry_run and tables:
             logger.warning("")
             logger.warning("=" * 80)
-            logger.warning("⚠️  PRODUCTION DROP WARNING ⚠️")
+            logger.warning("⚠️  DESTRUCTIVE DROP WARNING ⚠️")
             logger.warning("=" * 80)
-            logger.warning(f"You are about to DROP {len(tables)} table(s)/view(s) from PRODUCTION schema(s)!")
-            logger.warning(f"Schema: {schema_or_pattern}")
+            logger.warning(f"You are about to DROP {len(tables)} table(s)/view(s) outside the dev namespace!")
+            logger.warning(f"Non-dev schema(s) affected: {', '.join(non_dev_schemas)}")
             logger.warning("=" * 80)
             logger.warning("")
             

--- a/tests/test_drop_tables.py
+++ b/tests/test_drop_tables.py
@@ -1,0 +1,296 @@
+"""
+Regression tests for the safety guards in scripts/drop_tables.py.
+
+Uses only the standard library, so it needs no additional dependencies and no
+change to uv.lock. Run with:
+
+    uv run python -m unittest discover tests
+    # or
+    python3 -m unittest discover tests
+
+The Trino driver is stubbed, so these tests never open a connection or touch
+real data. Every DROP statement the script would issue is captured instead.
+
+Covers the bypass reported against the original guards, where both the prod
+check and the confirmation prompt keyed off the --target flag rather than the
+schema actually being targeted, so supplying --schema skipped both.
+"""
+
+import importlib.util
+import logging
+import os
+import re
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+TEAM_NAME = "my_team"
+
+# Simulated contents of dune.information_schema.tables.
+CATALOG_FIXTURE = [
+    ("my_team", "positions_daily", "BASE TABLE"),
+    ("my_team", "trades_enriched", "BASE TABLE"),
+    ("my_team", "reporting_view", "VIEW"),
+    ("my_team__tmp_", "scratch_model", "BASE TABLE"),
+    ("my_team__tmp_pr42", "scratch_model", "BASE TABLE"),
+    ("scratch_area", "junk", "BASE TABLE"),
+    ("other_team", "their_table", "BASE TABLE"),
+]
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "drop_tables.py"
+
+
+def setUpModule():
+    """Silence the script's own logging so test output stays readable."""
+    logging.disable(logging.CRITICAL)
+
+
+def tearDownModule():
+    logging.disable(logging.NOTSET)
+
+
+def like_to_regex(pattern):
+    """Mirror SQL LIKE semantics: % matches any run, _ matches one character."""
+    out = ""
+    for char in pattern:
+        if char == "%":
+            out += ".*"
+        elif char == "_":
+            out += "."
+        else:
+            out += re.escape(char)
+    return re.compile("^" + out + "$")
+
+
+class FakeCursor:
+    def __init__(self, recorder):
+        self._recorder = recorder
+        self._rows = []
+
+    def execute(self, query, params=None):
+        normalized = " ".join(query.lower().split())
+        if "information_schema.tables" in normalized:
+            if "table_schema like" in normalized:
+                matcher = like_to_regex(params[1])
+                self._rows = [r for r in CATALOG_FIXTURE if matcher.match(r[0])]
+            elif "table_name = ?" in normalized:
+                self._rows = [
+                    r for r in CATALOG_FIXTURE if r[0] == params[1] and r[1] == params[2]
+                ]
+            else:
+                self._rows = [r for r in CATALOG_FIXTURE if r[0] == params[1]]
+        elif normalized.startswith("drop "):
+            self._recorder.append(query)
+            self._rows = []
+
+    def fetchall(self):
+        return self._rows
+
+    def close(self):
+        pass
+
+
+class FakeConnection:
+    def __init__(self, recorder):
+        self._recorder = recorder
+
+    def cursor(self):
+        return FakeCursor(self._recorder)
+
+    def close(self):
+        pass
+
+
+class DropTablesTestCase(unittest.TestCase):
+    """Base class providing an isolated, offline invocation of the script."""
+
+    def run_script(self, argv, confirm_response="yes"):
+        """
+        Run drop_tables.main() with the given argv.
+
+        Returns:
+            tuple: (exit_code, dropped_statements, was_prompted)
+        """
+        recorded_drops = []
+        prompted = {"value": False}
+
+        trino_stub = types.ModuleType("trino")
+        dbapi = types.ModuleType("trino.dbapi")
+        auth = types.ModuleType("trino.auth")
+        dbapi.connect = lambda **kwargs: FakeConnection(recorded_drops)
+        dbapi.Connection = FakeConnection
+        auth.BasicAuthentication = lambda *args, **kwargs: None
+        trino_stub.dbapi = dbapi
+        trino_stub.auth = auth
+
+        stub_modules = {
+            "trino": trino_stub,
+            "trino.dbapi": dbapi,
+            "trino.auth": auth,
+        }
+        env = {
+            "DUNE_API_KEY": "fake-key-not-real",
+            "DUNE_TEAM_NAME": TEAM_NAME,
+        }
+
+        def fake_input(prompt=""):
+            prompted["value"] = True
+            return confirm_response
+
+        with mock.patch.dict(sys.modules, stub_modules), mock.patch.dict(
+            os.environ, env
+        ), mock.patch("builtins.input", fake_input), mock.patch.object(
+            sys, "argv", ["drop_tables.py"] + argv
+        ):
+            spec = importlib.util.spec_from_file_location(
+                "drop_tables_under_test", SCRIPT_PATH
+            )
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            exit_code = module.main()
+
+        return exit_code, recorded_drops, prompted["value"]
+
+    @staticmethod
+    def schemas_touched(drops):
+        """Extract the schema from each captured DROP statement."""
+        return sorted({stmt.split(".")[1].strip('"') for stmt in drops})
+
+
+class TestBulkDropIsScopedToDevSchemas(DropTablesTestCase):
+    def test_prod_schema_bulk_drop_is_refused_without_target_flag(self):
+        """The reported bypass: --schema <prod> --execute must not drop anything."""
+        exit_code, drops, prompted = self.run_script(["--schema", TEAM_NAME, "--execute"])
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(drops, [])
+        self.assertFalse(prompted)
+
+    def test_bare_wildcard_is_refused(self):
+        """--schema % must never fan out across every schema in the catalog."""
+        exit_code, drops, _ = self.run_script(["--schema", "%", "--execute"])
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(drops, [])
+
+    def test_prefix_wildcard_spanning_prod_is_refused(self):
+        """A pattern reaching both prod and dev schemas must be refused."""
+        exit_code, drops, _ = self.run_script(["--schema", f"{TEAM_NAME}%", "--execute"])
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(drops, [])
+
+    def test_unrelated_schema_bulk_drop_is_refused(self):
+        exit_code, drops, _ = self.run_script(["--schema", "other_team", "--execute"])
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(drops, [])
+
+
+class TestIntendedWorkflowsStillFunction(DropTablesTestCase):
+    def test_default_dev_bulk_drop_targets_only_tmp_schemas(self):
+        exit_code, drops, prompted = self.run_script(["--execute"])
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(self.schemas_touched(drops), ["my_team__tmp_", "my_team__tmp_pr42"])
+        self.assertFalse(prompted, "dev schemas are disposable and should not prompt")
+
+    def test_single_dev_schema_bulk_drop_is_allowed(self):
+        exit_code, drops, _ = self.run_script(["--schema", "my_team__tmp_pr42", "--execute"])
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(self.schemas_touched(drops), ["my_team__tmp_pr42"])
+
+    def test_dry_run_is_the_default(self):
+        exit_code, drops, _ = self.run_script([])
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(drops, [], "no DDL should execute without --execute")
+
+    def test_single_prod_table_drop_is_allowed_with_confirmation(self):
+        exit_code, drops, prompted = self.run_script(
+            [
+                "--target",
+                "prod",
+                "--schema",
+                TEAM_NAME,
+                "--table",
+                "positions_daily",
+                "--execute",
+            ]
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertTrue(prompted, "dropping a prod object must be confirmed")
+        self.assertEqual(len(drops), 1)
+        self.assertIn("positions_daily", drops[0])
+
+    def test_prod_bulk_drop_via_target_flag_still_refused(self):
+        exit_code, drops, _ = self.run_script(["--target", "prod", "--execute"])
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(drops, [])
+
+
+class TestConfirmationBehaviour(DropTablesTestCase):
+    def test_single_non_dev_drop_prompts_even_without_target_prod(self):
+        """Previously this path skipped the prompt entirely."""
+        exit_code, drops, prompted = self.run_script(
+            ["--schema", TEAM_NAME, "--table", "positions_daily", "--execute"]
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertTrue(prompted)
+        self.assertEqual(len(drops), 1)
+
+    def test_declining_confirmation_drops_nothing(self):
+        exit_code, drops, prompted = self.run_script(
+            ["--schema", TEAM_NAME, "--table", "positions_daily", "--execute"],
+            confirm_response="no",
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertTrue(prompted)
+        self.assertEqual(drops, [])
+
+    def test_view_uses_drop_view(self):
+        exit_code, drops, _ = self.run_script(
+            ["--schema", TEAM_NAME, "--table", "reporting_view", "--execute"]
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertTrue(drops[0].lower().startswith("drop view"))
+
+
+class TestExplicitOptIn(DropTablesTestCase):
+    def test_opt_in_allows_bulk_drop_of_non_dev_schema(self):
+        exit_code, drops, prompted = self.run_script(
+            ["--schema", "scratch_area", "--allow-bulk-outside-dev", "--execute"]
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertTrue(prompted, "opting in still requires confirmation")
+        self.assertEqual(self.schemas_touched(drops), ["scratch_area"])
+
+    def test_opt_in_cannot_bulk_drop_the_production_schema(self):
+        exit_code, drops, _ = self.run_script(
+            ["--schema", TEAM_NAME, "--allow-bulk-outside-dev", "--execute"]
+        )
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(drops, [])
+
+    def test_opt_in_cannot_bulk_drop_prod_via_wildcard(self):
+        exit_code, drops, _ = self.run_script(
+            ["--schema", "%", "--allow-bulk-outside-dev", "--execute"]
+        )
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(drops, [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

`scripts/drop_tables.py` could bulk-drop every object in the production schema with no guard and no confirmation:

```bash
python scripts/drop_tables.py --schema my_team --execute
```

Both safety mechanisms, the "prod requires `--schema` and `--table`" check and the interactive confirmation, were gated on `is_prod`, which was derived solely from the `--target` flag:

```python
is_prod = args.target == "prod"
```

`--schema` overrides the resolved schema without influencing that flag, so supplying it skipped both guards while still targeting production. The guard protected the flag, not the namespace.

`--schema` is also interpolated into a SQL `LIKE` comparison rather than an equality check, so it is a pattern. That widens the issue considerably: `--schema %` matched every schema visible to the API key and bulk-dropped all of it. `--schema my_team` behaved as an exact match only because it happens to contain no wildcard characters. The README documented `--schema test_% --execute`, so passing wildcards was presented as normal usage.

Reported by a customer engineer, who also correctly identified the root cause and proposed this general shape of fix.

## What changed

Guards now key off the schema being targeted rather than the `--target` flag:

- Bulk drops (no `--table`) are limited to the `{DUNE_TEAM_NAME}__tmp_` dev namespace.
- Validation happens twice: up front on the requested pattern, then again on the schemas the query actually resolved to. The second check is authoritative, since it holds regardless of how `LIKE` expanded the pattern. This matters because `_` is itself a single-character wildcard, so the dev prefix cannot be safely validated by pattern comparison alone.
- The production schema can never be bulk-dropped, with or without the new opt-in flag.
- Bulk-dropping another non-production schema requires an explicit `--allow-bulk-outside-dev` flag plus interactive confirmation. This preserves the previously documented `test_%` cleanup workflow rather than removing it.
- Any drop touching a schema outside the dev namespace now requires confirmation. Previously only `--target prod` did, so `--schema my_team --table x --execute` dropped a production object silently.

Existing intended workflows are unchanged: the default dev bulk drop, single dev schema bulk drops, dry-run-by-default, and the `--target prod --schema X --table Y` path all behave exactly as before.

## Tests

`tests/test_drop_tables.py` stubs the Trino driver, so the tests never open a connection or touch real data. Every DROP statement the script would issue is captured and asserted against.

Standard library only, so no new dependencies and `pyproject.toml` / `uv.lock` are untouched:

```bash
python3 -m unittest discover tests
```

15 tests covering each bypass, each intended workflow, confirmation behaviour, and the opt-in flag. **Nine fail against the previous implementation.** The six that pass on both confirm existing workflows are preserved.

Also adds `.github/workflows/scripts_tests.yml` to actually run them. The dbt CI workflow is disabled by default because of credit costs, so without this the new guards would have no CI coverage and could silently regress, which is the same failure mode that allowed this bug. These tests consume no credits and need no secrets.

## Docs

`scripts/README.md` stated "Bulk drops are not allowed" for prod, which was untrue whenever `--schema` was supplied. It also documented the unguarded `--schema my_custom_schema --execute` path as routine. Both corrected, along with a note that `--schema` is a LIKE pattern rather than a literal name.

## Note for reviewers

There is one related follow-up question that concerns platform behaviour rather than this
script, which I have raised with the team internally rather than here.

Made with [Cursor](https://cursor.com)


