### PR TITLE
docs: correct drop_tables.py safety claims

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,13 +6,30 @@ This directory contains utility scripts for managing your Dune dbt project.
 
 Drops tables and views in a Dune schema via the Trino API endpoint.
 
+> **Status: optional, unsupported utility.** This script exists so teams can clean
+> up the dev, CI and archived tables that a dbt project accumulates and that would
+> otherwise keep accruing storage cost. It is not part of the dbt connector path —
+> nothing in the models, macros, or workflows invokes it — and it is not covered by
+> automated tests. If your team does not need periodic cleanup, you can delete
+> `scripts/drop_tables.py` from your repository with no effect on dbt.
+
+> **⚠️ There are no production guardrails.** The `--target prod` restrictions
+> described below are keyed to the `--target` flag, not to the schema name. Because
+> `--schema` overrides the target's default schema, running
+> `--schema <your_prod_schema> --execute` performs an unconfirmed bulk drop of every
+> object in that schema. Treat every `--execute` run as unguarded: run it without
+> `--execute` first and read the list of DROP statements.
+
 ### Purpose
 
 This script connects to the Dune Trino API using the same configuration as dbt and drops tables and views based on:
-- **Target environment** (dev or prod)
-  - `dev` (default): Drops all tables matching `{DUNE_TEAM_NAME}__tmp_%` pattern (bulk drops allowed)
-  - `prod`: **Only allows dropping ONE specific table/view at a time** (requires `--schema` and `--table`)
-- **Schema pattern matching** (dev only - override with `--schema` for custom patterns)
+- **Target environment** (dev or prod), which selects the *default* schema and, for
+  prod, the single-table checks
+  - `dev` (default): schema pattern `{DUNE_TEAM_NAME}__tmp_%`, bulk drops allowed
+  - `prod`: schema `{DUNE_TEAM_NAME}`, with the checks described under
+    [Drop Prod Tables](#drop-prod-tables)
+- **Schema name or pattern** via `--schema`, which overrides the target default and
+  is not limited to dev schemas
 - **Specific table/view** (drop a single table or view)
 
 The script uses `INFORMATION_SCHEMA.TABLES` to find tables and generates appropriate `DROP TABLE` or `DROP VIEW` commands based on the object type.
@@ -22,10 +39,12 @@ The script uses `INFORMATION_SCHEMA.TABLES` to find tables and generates appropr
 - S3 cleanup should be handled separately via scheduled cleanup jobs
 - This script does not clean up S3 data (requires separate AWS access)
 
-**Production Safety**: 
-- Prod drops require BOTH `--schema` AND `--table` (no bulk drops)
-- Interactive confirmation is required before executing prod drops
-- This ensures prod drops are deliberate, specific, and rare
+**Checks applied when `--target prod` is passed**:
+- Requires BOTH `--schema` AND `--table`, so no bulk drop is possible
+- Requires interactive confirmation before executing
+
+These two checks test the value of the `--target` flag. They are **not** applied when
+the production schema is named with `--schema` on the default `dev` target.
 
 ### Prerequisites
 
@@ -56,9 +75,12 @@ python scripts/drop_tables.py --execute
 
 #### Drop Prod Tables
 
-⚠️ **Production Restriction**: For safety, prod drops require BOTH `--schema` AND `--table`.
+⚠️ **This restriction is scoped to the `--target prod` flag, not to the schema.** When
+you pass `--target prod`, the script requires both `--schema` and `--table` and will not
+bulk drop. Naming the same production schema via `--schema` on the default `dev` target
+skips the restriction entirely.
 
-You can only drop **one specific table/view at a time** in prod. Bulk drops are not allowed.
+Under `--target prod` you can only drop **one specific table/view at a time**.
 
 ```bash
 # Dry run - drop specific prod table
@@ -68,15 +90,20 @@ python scripts/drop_tables.py --target prod --schema dune --table my_table
 python scripts/drop_tables.py --target prod --schema dune --table my_table --execute
 ```
 
-**⚠️ Production Safety**: When using `--target prod` with `--execute`:
+**When using `--target prod` with `--execute`**:
 1. You MUST specify both `--schema` and `--table` (no pattern matching)
 2. Script confirms the specific table that will be dropped
 3. Requires you to type `yes` to confirm
 4. Operation is cancelled if you type anything else or press Ctrl+C
 
-**This restriction ensures prod drops are deliberate, specific, and rare.**
+**All four steps depend on `--target prod` being passed.** Reaching the same schema
+through `--schema` on the default target skips all of them.
 
 #### Drop Specific Schema
+
+⚠️ **This path applies no restrictions and asks for no confirmation.** `--schema`
+accepts any schema name, including your production schema, and drops every object it
+finds there. Run it without `--execute` first and read the output.
 
 Drop all tables in a specific schema (exact match):
 
@@ -242,16 +269,31 @@ The script uses the following connection configuration (matching `profiles.yml`)
 - Default pattern `{DUNE_TEAM_NAME}__tmp_%` matches all dev schemas
 - The `%` wildcard matches any characters (including none)
 - You can provide custom patterns with `--schema` (e.g., `test_%`, `staging_%`)
+- Custom patterns are **not** confined to dev schemas, and the resulting list of
+  objects is not filtered afterwards. A broad pattern such as `%` matches every schema
+  the API key can see
 
 This approach is particularly useful for:
 - Cleaning up all dev schemas at once (including PR schemas)
 - Cleaning up after CI/CD test runs
 - Removing temporary tables from pattern-matched schemas
 
-### Safety Features
+### What the script does protect against
 
-- **Dry run by default**: Prevents accidental deletions
-- **Clear logging**: All DROP commands are displayed before execution
-- **Pattern visibility**: Shows which schemas are matched before dropping
-- **Summary reporting**: Confirms what was dropped and if any failures occurred
-- **Uses `IF EXISTS`**: DROP commands won't fail if table doesn't exist
+- **Dry run by default**: nothing is dropped unless `--execute` is passed
+- **Clear logging**: all DROP commands are displayed before execution
+- **Pattern visibility**: shows which schemas are matched before dropping
+- **Summary reporting**: reports what was dropped and whether any drops failed
+- **Uses `IF EXISTS`**: DROP commands won't fail if the table doesn't exist
+
+### What it does not protect against
+
+- **Bulk drops of a production schema.** `--schema <prod_schema> --execute` drops every
+  object in that schema with no confirmation prompt
+- **Broad schema patterns.** A wildcard `--schema` value is not restricted to dev
+  schemas
+- **Partial failures.** Individual drop failures are logged and the run continues, so a
+  rejected drop and a successful one can look similar in a long output
+
+The dry run is the control. Read it before adding `--execute`, and if your team has no
+need for periodic cleanup, delete `scripts/drop_tables.py`.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -17,8 +17,13 @@ Drops tables and views in a Dune schema via the Trino API endpoint.
 > described below are keyed to the `--target` flag, not to the schema name. Because
 > `--schema` overrides the target's default schema, running
 > `--schema <your_prod_schema> --execute` performs an unconfirmed bulk drop of every
-> object in that schema. Treat every `--execute` run as unguarded: run it without
-> `--execute` first and read the list of DROP statements.
+> object in that schema. Treat every `--execute` run as unguarded.
+
+> **Required workflow.** Always run the command without `--execute` first and review
+> every DROP statement. Only after confirming the complete list should you rerun the
+> same command with `--execute`. Execute mode does not pause for review before dropping
+> dev or custom-schema objects: it logs each DROP statement as it issues it, so by the
+> time a statement appears in the output, that object has already been dropped.
 
 ### Purpose
 
@@ -135,8 +140,8 @@ python scripts/drop_tables.py --table my_table_name --schema my_schema --execute
 # Verbose logging for debugging
 python scripts/drop_tables.py --verbose
 
-# Specify API key directly (instead of using env var)
-python scripts/drop_tables.py --execute --api-key YOUR_API_KEY_HERE
+# Specify API key directly (instead of using env var) - dry run
+python scripts/drop_tables.py --api-key YOUR_API_KEY_HERE
 ```
 
 ### Command-Line Arguments
@@ -181,7 +186,10 @@ python scripts/drop_tables.py --target prod --schema dune --table my_model
 # Drop specific PROD table (execute - REQUIRES CONFIRMATION)
 python scripts/drop_tables.py --target prod --schema dune --table my_model --execute
 
-# Drop with custom pattern (any dev schema starting with 'test_')
+# Drop with custom pattern (any schema starting with 'test_') - dry run first
+python scripts/drop_tables.py --schema test_%
+
+# Drop with custom pattern (execute, only after reviewing the dry run above)
 python scripts/drop_tables.py --schema test_% --execute
 
 # Verbose output for debugging
@@ -281,8 +289,11 @@ This approach is particularly useful for:
 ### What the script does protect against
 
 - **Dry run by default**: nothing is dropped unless `--execute` is passed
-- **Clear logging**: all DROP commands are displayed before execution
-- **Pattern visibility**: shows which schemas are matched before dropping
+- **A complete dry-run listing**: without `--execute`, every DROP statement and every
+  matched schema is printed and nothing is executed. This is the only point at which
+  you get the full list before any object is dropped
+- **Statement-level logging in execute mode**: each DROP statement is logged as it is
+  issued, so the output is an audit trail of what was attempted
 - **Summary reporting**: reports what was dropped and whether any drops failed
 - **Uses `IF EXISTS`**: DROP commands won't fail if the table doesn't exist
 
@@ -290,6 +301,10 @@ This approach is particularly useful for:
 
 - **Bulk drops of a production schema.** `--schema <prod_schema> --execute` drops every
   object in that schema with no confirmation prompt
+- **A review step in execute mode.** Only the object count is printed before dropping
+  begins. Individual DROP statements are logged as they are issued, not gathered into a
+  list you approve first, so there is no opportunity to abort partway on the basis of
+  the output. The dry run is the review step
 - **Broad schema patterns.** A wildcard `--schema` value is not restricted to dev
   schemas
 - **Partial failures.** Individual drop failures are logged and the run continues, so a

--- a/scripts/drop_tables.py
+++ b/scripts/drop_tables.py
@@ -8,6 +8,18 @@ as dbt and drops tables and views based on schema pattern or specific table name
 NOTE: Trino's DROP TABLE command only removes the metastore entry, leaving orphaned
 data in S3. S3 cleanup should be handled separately via scheduled cleanup jobs.
 
+REQUIRED WORKFLOW: Always run the command without --execute first and review every
+DROP statement. Only after confirming the complete list should you rerun the same
+command with --execute. Execute mode does not pause for review before dropping dev or
+custom-schema objects: each DROP statement is logged as it is issued, so by the time a
+statement appears in the output, that object has already been dropped.
+
+WARNING: There are no production guardrails. The --target prod restrictions are keyed
+to the --target flag, not to the schema name. Because --schema overrides the target's
+default schema, `--schema <prod_schema> --execute` performs an unconfirmed bulk drop of
+every object in that schema. This script is an optional, unsupported helper; if your
+team does not need periodic cleanup, delete it.
+
 Usage:
     # Dry run - drop all tables matching DUNE_TEAM_NAME__tmp_* pattern
     python scripts/drop_tables.py
@@ -18,10 +30,10 @@ Usage:
     # Dry run - drop specific table
     python scripts/drop_tables.py --table my_table_name --schema my_schema
 
-    # Actually execute drops
+    # Execute drops (only after reviewing the matching dry run above)
     python scripts/drop_tables.py --execute
 
-    # Execute drop for specific schema
+    # Execute drop for specific schema (only after reviewing its dry run)
     python scripts/drop_tables.py --schema my_schema --execute
 """
 
@@ -422,18 +434,37 @@ def main():
         description="Drop tables and views in a Dune schema via Trino API",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
+REQUIRED WORKFLOW:
+  1. Run the intended command WITHOUT --execute.
+  2. Review the complete list of DROP statements.
+  3. Only then rerun the same command with --execute.
+
+  Execute mode does not pause for review before dropping dev or custom-schema
+  objects. Each DROP statement is logged as it is issued, so by the time you see
+  a line, that object has already been dropped.
+
+  There are no production guardrails. The --target prod restrictions below are
+  keyed to the --target flag, not to the schema name, so
+  `--schema <prod_schema> --execute` bulk-drops that schema without confirmation.
+
 Examples:
   # Dry run - drop all dev tables (DUNE_TEAM_NAME__tmp_* pattern)
   python scripts/drop_tables.py
 
-  # Execute drop for dev tables
+  # Execute drop for dev tables (only after reviewing the dry run above)
   python scripts/drop_tables.py --execute
 
   # Drop specific dev table (dry run)
   python scripts/drop_tables.py --table my_table --schema dune__tmp_jeff
 
-  # Drop specific dev table (execute)
+  # Drop specific dev table (execute, after reviewing its dry run)
   python scripts/drop_tables.py --table my_table --schema dune__tmp_jeff --execute
+
+  # Drop with custom pattern (dry run)
+  python scripts/drop_tables.py --schema test_%
+
+  # Drop with custom pattern (execute, after reviewing its dry run)
+  python scripts/drop_tables.py --schema test_% --execute
 
   # Drop specific prod table (dry run - REQUIRES --schema AND --table)
   python scripts/drop_tables.py --target prod --schema dune --table my_table


### PR DESCRIPTION
## Problem

`scripts/README.md` makes affirmative safety guarantees that the shipped code does not honour:

- Line 26: "Prod drops require BOTH `--schema` AND `--table` (no bulk drops)"
- Line 27: "Interactive confirmation is required before executing prod drops"
- Line 59: "**Production Restriction**: For safety, prod drops require BOTH `--schema` AND `--table`."

Both checks read the `--target` flag rather than the schema being operated on. Because `--schema` overrides the target's default schema without changing the flag, this bypasses both:

```bash
python scripts/drop_tables.py --schema <prod_schema> --execute
```

That performs a bulk drop of every object in the production schema with no confirmation prompt, while the README states it cannot happen. Reported by a customer engineer who read the documented guarantees and tested them.

A second overstatement surfaced in review: the "Safety Features" list implied a complete set of DROP statements is presented for approval before anything is dropped. That is only true of the dry run. In execute mode `drop_tables()` prints the object count, then logs and issues each statement one at a time, so a statement appearing in the output means that object is already gone.

## What this PR does

Text only. No behaviour change, no logic touched.

`scripts/README.md`:

- Scopes the prod checks to the `--target prod` flag they actually test, in all three places that describe them
- States the required workflow explicitly: dry run, review the complete list, then rerun the same command with `--execute`
- Warns that there are no production guardrails on the `--schema` path, and adds a warning to the "Drop Specific Schema" section
- Notes that custom `--schema` patterns are not confined to dev schemas
- Distinguishes the complete dry-run listing from statement-level logging in execute mode
- Replaces "Safety Features" with two sections: what the script protects against, and what it does not, including the absence of a review step in execute mode
- Shows the custom-pattern and api-key examples as dry runs rather than destructive one-liners
- Marks the script as an optional, unsupported utility, and notes it can be deleted since nothing in the dbt project invokes it

`scripts/drop_tables.py` (module docstring and argparse epilog only):

- Carries the required workflow and the missing-guardrail warning into `--help`, for users who never open the README

## Why docs rather than a code fix

A code fix was proposed separately and closed. The consensus was that this is an optional ad-hoc helper rather than maintained tooling, which is a reasonable position — but it does not hold together with a README that promises protections the code does not implement. This change makes the documentation match the code and reduces maintained surface rather than adding any.

If the script is removed from the template later, this file goes with it.