### PR TITLE
Rename table visibility to table privacy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this template will be documented in this file.
 ### Added
 - **DataShare CDF**: `meta.datashare.is_cdf` opts a model into DataShare CDF delivery instead of the legacy time-window sync, with optional `meta.datashare.partitioning` to partition the share on a raw date/timestamp column. CDF is watermark-driven, so the `time_*` keys do not apply. Delivery is Snowflake-only, so set `target_type: snowflake`. See `docs/dune-datashares.md`.
 
+### Changed
+- **Renamed "table visibility" to "table privacy"** (breaking): the `set_table_visibility` macro is now `set_table_privacy`, `macros/dune_dbt_overrides/set_table_visibility.sql` is now `set_table_privacy.sql`, and `docs/dune-table-visibility.md` is now `docs/dune-table-privacy.md`. Dune's catalog already uses "visibility" for a separate, admin-only property that controls Data Explorer listing. If you call `set_table_visibility` outside the `dbt_project.yml` post-hook, rename the call. The `meta.dune.public` config and the underlying `dune.public` property are unchanged.
+- **Clarified view privacy**: the post-hook still skips views, but the docs no longer imply this leaves them exposed. A view's privacy cannot be changed after creation, and reading a view authorizes against each underlying table, so a view over private tables stays restricted.
+
 ### Fixed
 - **Datashare `run-operation` could sync dev schemas**: `datashare_trigger_sync_operation` had no target guard, so running it without `--target prod` registered the dev temp schema (`<team>__tmp_<suffix>`) as a real datashare and shipped it to the destination warehouse. It now raises a clear error outside `prod`, naming the schema it would have registered. `dry_run: true` is still permitted on any target, and `allow_prod_only: false` is available as an explicit override.
 - **Datashare docs omitted `--target prod`**: all `run-operation` examples in `docs/dune-datashares.md` now pass `--target prod`, with a note explaining why it matters.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ When you're ready to enable automated dbt runs on PRs, pushes to main, or a sche
 - **[Getting Started](docs/getting-started.md)** - Initial setup for new developers
 - **[Development Workflow](docs/development-workflow.md)** - How to develop models
 - **[dbt Best Practices](docs/dbt-best-practices.md)** - Patterns and configurations
-- **[Dune Table Visibility](docs/dune-table-visibility.md)** - Control public/private access to tables
+- **[Dune Table Privacy](docs/dune-table-privacy.md)** - Control public/private access to tables
 - **[Dune Datashares](docs/dune-datashares.md)** - Sync tables to external warehouses
 - **[Testing](docs/testing.md)** - Test requirements
 - **[CI/CD](docs/cicd.md)** - GitHub Actions workflows
@@ -205,7 +205,7 @@ This template includes an opt-in datashare post-hook for `table` and `incrementa
 
 See [docs/dune-datashares.md](docs/dune-datashares.md) for the full setup, `run-operation` examples, monitoring queries, and cleanup commands.
 
-## Table Visibility
+## Table Privacy
 
 By default, all tables are **private** — only your team can see or query them. Setting `meta.dune.public: true` makes a table accessible to all Dune users: queryable via the SQL editor, API, dashboards, and visible in the data explorer.
 
@@ -221,9 +221,9 @@ By default, all tables are **private** — only your team can see or query them.
 ) }}
 ```
 
-Visibility is only applied in the `prod` target and has no effect in development. Views are not supported at this time.
+Privacy is only applied in the `prod` target and has no effect in development. Views are skipped: their privacy cannot be changed after creation, and a view over private tables stays restricted anyway.
 
-See **[Dune Table Visibility](docs/dune-table-visibility.md)** for folder-level config, incremental models, and raw SQL reference.
+See **[Dune Table Privacy](docs/dune-table-privacy.md)** for folder-level config, incremental models, and raw SQL reference.
 
 ## GitHub Actions
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -34,7 +34,7 @@ models:
     +materialized: view       # fallback default, materialized should be overriden in model specific configs
     +view_security: invoker   # required security setting for views
     +post-hook:
-      - sql: "{{ set_table_visibility(this, model.config.materialized) }}"
+      - sql: "{{ set_table_privacy(this, model.config.materialized) }}"
         transaction: true
       - sql: "{{ optimize_table(this, model.config.materialized) }}"
         transaction: true

--- a/docs/dune-table-privacy.md
+++ b/docs/dune-table-privacy.md
@@ -1,12 +1,12 @@
-# Dune Table Visibility
+# Dune Table Privacy
 
 Control whether a table is accessible to other Dune users using the `meta.dune.public` config.
 
 By default, tables created by dbt are **private** — only your team can see or query them. Public tables are accessible to all Dune users: they appear in the data explorer, can be queried via the SQL editor or API, and can be referenced in other users' queries and dashboards.
 
-For the full SQL reference, see the [official Dune docs on Table Visibility](https://docs.dune.com/api-reference/connectors/sql-operations#table-visibility).
+For the full SQL reference, see the [official Dune docs on Table Privacy](https://docs.dune.com/api-reference/connectors/sql-operations#table-privacy).
 
-Implemented by [`macros/dune_dbt_overrides/set_table_visibility.sql`](../macros/dune_dbt_overrides/set_table_visibility.sql).
+Implemented by [`macros/dune_dbt_overrides/set_table_privacy.sql`](../macros/dune_dbt_overrides/set_table_privacy.sql).
 
 ## dbt config
 
@@ -26,14 +26,14 @@ Set `meta.dune.public` in your model config:
 select ...
 ```
 
-The `set_table_visibility` post-hook runs `ALTER TABLE ... SET PROPERTIES extra_properties = ...` automatically after each model run.
+The `set_table_privacy` post-hook runs `ALTER TABLE ... SET PROPERTIES extra_properties = ...` automatically after each model run.
 
-| `meta.dune.public` | Visibility |
+| `meta.dune.public` | Privacy |
 |---|---|
 | `true` | Public — queryable by all Dune users, visible in data explorer, SQL editor, API |
 | `false` or absent | Private (default) — only accessible to your team |
 
-Visibility is only applied in the **`prod` target** — it has no effect in development.
+Privacy is only applied in the **`prod` target** — it has no effect in development.
 
 ## Folder-level config
 
@@ -50,7 +50,7 @@ models:
 
 ## Incremental models
 
-Same config — the post-hook runs on every `dbt run`, so visibility is kept in sync:
+Same config — the post-hook runs on every `dbt run`, so privacy is kept in sync:
 
 ```sql
 {{ config(
@@ -73,9 +73,9 @@ select ...
 
 ## Views
 
-View visibility is **not supported** by the post-hook macro at this time.
+The post-hook skips views, because a view's privacy cannot be changed after it is created. This does not leave data exposed: reading a view still authorizes against each underlying table, so a view over private tables stays restricted to your team.
 
-## Changing visibility on existing tables
+## Changing privacy on existing tables
 
 Via any Trino client or `dbt run-operation`:
 

--- a/macros/dune_dbt_overrides/set_table_privacy.sql
+++ b/macros/dune_dbt_overrides/set_table_privacy.sql
@@ -7,8 +7,8 @@
   ])
 {%- endmacro -%}
 
-{# post-hook that sets dune.public via ALTER TABLE on every table/incremental run (prod only). Setting visibility for views is not supported at this time. #}
-{% macro set_table_visibility(this, materialization) %}
+{# post-hook that sets dune.public via ALTER TABLE on every table/incremental run (prod only). Views are skipped: their privacy cannot be changed after creation, and a view over private tables stays restricted anyway. #}
+{% macro set_table_privacy(this, materialization) %}
 {%- if target.name == 'prod'
     and materialization in ('table', 'incremental') -%}
   {%- set dune_public = config.get('meta', {}).get('dune', {}).get('public', false) -%}


### PR DESCRIPTION
Dune's catalog already uses "visibility" for a separate, admin-only property (`dune.visible`) that controls whether a table is listed in the Data Explorer. Using the same word for `dune.public` overloads the term, so this renames the user-facing concept to privacy: `set_table_visibility` becomes `set_table_privacy`, and the macro file and doc page follow. The `meta.dune.public` config and the underlying `dune.public` property are unchanged.

This is breaking for anyone who forked the template and calls the macro outside the `dbt_project.yml` post-hook, so there's a CHANGELOG entry rather than a compatibility shim.

Also corrects the view wording. The docs said view visibility was "not supported", which read as though views were left exposed. In fact a view's privacy cannot be changed after creation (`alter_view_properties` is admin-only), and it does not need to be: views store no owner and so run as invoker, meaning a read authorizes against each underlying table. A view over private tables stays restricted to your team.

Verified with `dbt deps && dbt parse` — the manifest registers `macro.dbt_template.set_table_privacy` and the post-hook resolves to it.

Depends on duneanalytics/dune-docs#1189 for the `#table-privacy` anchor this doc links to; merge that first.

Fixes DWH-548