### PR TITLE
feat: route datashare models into the DataShare CDF contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this template will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **DataShare CDF**: `meta.datashare.is_cdf` opts a model into DataShare CDF delivery instead of the legacy time-window sync, with optional `meta.datashare.partitioning` to partition the share on a raw date/timestamp column. CDF is watermark-driven, so the `time_*` keys do not apply. Delivery is Snowflake-only, so set `target_type: snowflake`. See `docs/dune-datashares.md`.
+
 ### Fixed
 - **Datashare `run-operation` could sync dev schemas**: `datashare_trigger_sync_operation` had no target guard, so running it without `--target prod` registered the dev temp schema (`<team>__tmp_<suffix>`) as a real datashare and shipped it to the destination warehouse. It now raises a clear error outside `prod`, naming the schema it would have registered. `dry_run: true` is still permitted on any target, and `allow_prod_only: false` is available as an explicit override.
 - **Datashare docs omitted `--target prod`**: all `run-operation` examples in `docs/dune-datashares.md` now pass `--target prod`, with a note explaining why it matters.

--- a/docs/dune-datashares.md
+++ b/docs/dune-datashares.md
@@ -80,15 +80,47 @@ All datashare config lives under `meta.datashare` in the model `config()` block.
 | Property                 | Required | Type           | Description                                                                 |
 | ------------------------ | -------- | -------------- | --------------------------------------------------------------------------- |
 | `enabled`                | Yes      | `boolean`      | Must be `true` to trigger sync.                                             |
-| `time_column`            | Yes      | `string`       | Column used to define the sync window.                                      |
-| `time_start`             | Yes      | `string`       | SQL expression for the start of the full-refresh sync window.               |
+| `time_column`            | Yes\*    | `string`       | Column used to define the sync window. Not used when `is_cdf` is `true`.    |
+| `time_start`             | Yes\*    | `string`       | SQL expression for the start of the full-refresh sync window.               |
 | `time_start_incremental` | No       | `string`       | SQL expression for incremental runs. Falls back to `time_start` if omitted. |
 | `time_end`               | No       | `string`       | SQL expression for the end of the sync window. Defaults to `now()`.         |
 | `unique_key_columns`     | No       | `list[string]` | Row identity columns. Falls back to the model `unique_key` if omitted.      |
+| `is_cdf`                 | No       | `boolean`      | Opt into DataShare CDF delivery. Defaults to `false` (legacy path).         |
+| `partitioning`           | No       | `string`       | Raw, untransformed date/timestamp source column to partition the CDF share on. |
+
+\* Required for the legacy time-window path only. Omit them for `is_cdf: true` models.
 
 All time expressions are SQL, not literal timestamps. The macro wraps them in `CAST(... AS VARCHAR)` before calling the table procedure.
 
 Keep the sync window aligned with the `time_column` granularity. For example, if `time_column` is a `date`, use date-based expressions like `current_date - interval '1' day`, not hour-based timestamp windows.
+
+### DataShare CDF
+
+Set `meta.datashare.is_cdf: true` to route a model through the DataShare CDF contract instead of the legacy time-window sync. CDF is watermark-driven, so the time keys do not apply — delete them.
+
+Also set `target_type: snowflake`. CDF delivers to Snowflake only, and omitting the target is accepted by dbt but rejected once the statement reaches Trino.
+
+```sql
+{{ config(
+    materialized = 'incremental'
+    , incremental_strategy = 'merge'
+    , unique_key = ['block_number', 'block_date']
+    , meta = {
+        "datashare": {
+            "enabled": true,
+            "is_cdf": true,
+            "partitioning": "block_date",
+            "target_type": "snowflake"
+        }
+    }
+) }}
+
+select ...
+```
+
+`full_refresh` re-bootstraps the destination: it is re-copied in full from the current source snapshot instead of advancing from the last watermark. Changing `partitioning` on an existing sync requires it, and is rejected while a bootstrap is in flight.
+
+Setting `partitioning` without `is_cdf: true` is rejected by Trino, not by dbt.
 
 ## Cadence and sync windows
 
@@ -150,6 +182,8 @@ The macro determines `full_refresh` automatically:
 | Table materialization post-hook                        | `true`                    |
 | `run-operation`                                        | `false` unless overridden |
 
+For `is_cdf: true` models this table is the only source of `full_refresh`; there is no active-sync probe.
+
 ## Generated SQL
 
 The post-hook generates this Trino statement:
@@ -163,6 +197,20 @@ ALTER TABLE dune.<schema>.<table> EXECUTE datashare(
     full_refresh => true|false
 )
 ```
+
+With `is_cdf: true`, the time-window properties are dropped:
+
+```sql
+ALTER TABLE dune.<schema>.<table> EXECUTE datashare(
+    is_cdf => true,
+    unique_key_columns => ARRAY['col1', 'col2'],
+    full_refresh => true|false,
+    target_type => 'snowflake',
+    partitioning => '<column_name>'
+)
+```
+
+`target_type` / `target_region` / `partitioning` are appended in both modes only when configured.
 
 ## Manual Syncs
 

--- a/macros/dune_dbt_overrides/datashare_table_sync_post_hook.sql
+++ b/macros/dune_dbt_overrides/datashare_table_sync_post_hook.sql
@@ -81,6 +81,9 @@
         {{ log('Skipping datashare sync for ' ~ model_ref ~ ': materialization "' ~ materialized ~ '" is not incremental/table.') }}
         {{ return(none) }}
     {%- endif -%}
+    {%- set is_cdf = datashare.get('is_cdf') is sameas true -%}
+    {%- set partitioning = datashare.get('partitioning') -%}
+    {%- set include_partitioning = partitioning is not none and partitioning | string | trim != '' -%}
     {%- set time_column = datashare.get('time_column') -%}
     {%- set resolved_time_start = time_start if time_start is not none else datashare.get('time_start') -%}
     {%- set resolved_time_end = time_end if time_end is not none else datashare.get('time_end', 'now()') -%}
@@ -92,24 +95,36 @@
     {#- An incremental sync targets an existing destination via MERGE. If the
         destination sync was revoked while the source table still exists, dbt
         builds incrementally but there is nothing to merge into. Force a full
-        refresh when no active sync is registered for this table/target. -#}
-    {%- if not full_refresh and not _datashare_active_sync_exists(schema_name, table_name, target_type, target_region) -%}
+        refresh when no active sync is registered for this table/target.
+        CDF bootstrap classification happens on the Dune side instead: skip the
+        probe so an explicit CDF request is not forced through a spurious
+        re-bootstrap. -#}
+    {%- if not is_cdf and not full_refresh and not _datashare_active_sync_exists(schema_name, table_name, target_type, target_region) -%}
         {{ log('No active datashare sync for ' ~ model_ref ~ '; forcing full_refresh.', info=True) }}
         {%- set full_refresh = true -%}
     {%- endif -%}
 
     {%- set sql -%}
 ALTER TABLE {{ catalog_name }}.{{ schema_name }}.{{ table_name }} EXECUTE datashare(
+{%- if is_cdf -%}
+    is_cdf => true,
+    unique_key_columns => {{ _datashare_unique_key_columns_sql(datashare.get('unique_key_columns', unique_key)) }},
+    full_refresh => {{ 'true' if full_refresh else 'false' }}
+{%- else -%}
     time_column => {{ _datashare_sql_string(time_column | default('', true)) }},
     unique_key_columns => {{ _datashare_unique_key_columns_sql(datashare.get('unique_key_columns', unique_key)) }},
     time_start => {{ _datashare_optional_time_sql(resolved_time_start) }},
     time_end => {{ _datashare_optional_time_sql(resolved_time_end) }},
     full_refresh => {{ 'true' if full_refresh else 'false' }}
+{%- endif -%}
 {%- if include_target_type -%}
     , target_type => {{ _datashare_sql_string(target_type) }}
 {%- endif -%}
 {%- if include_target_region -%}
     , target_region => {{ _datashare_sql_string(target_region) }}
+{%- endif -%}
+{%- if include_partitioning -%}
+    , partitioning => {{ _datashare_sql_string(partitioning) }}
 {%- endif -%}
 )
     {%- endset -%}

--- a/models/templates/dbt_template_datashare_incremental_model.sql
+++ b/models/templates/dbt_template_datashare_incremental_model.sql
@@ -8,6 +8,17 @@
 -- `time_column` and an hour-sized window, every hourly run will re-read the
 -- full day from the destination (24x amplification on cross-region S3 buckets).
 -- For hourly freshness, see the "Hourly cadence" example in the docs.
+--
+-- To opt this model into DataShare CDF instead (see the "DataShare CDF"
+-- section of docs/dune-datashares.md), replace the time keys in meta.datashare
+-- below with:
+--   "is_cdf": true,
+--   "partitioning": "block_date",
+--   "target_type": "snowflake"
+--
+-- CDF is watermark-driven, so `time_column`, `time_start`,
+-- `time_start_incremental` and `time_end` are unused under `is_cdf` -- delete
+-- them from meta.datashare.
 {%- set time_start_incremental = "current_date - interval '1' day" -%}
 {%- set time_start = "current_date - interval '2' day" -%}
 {%- set time_end = "current_date + interval '1' day" -%}


### PR DESCRIPTION
Adds `meta.datashare.is_cdf` so a model can opt into DataShare CDF delivery instead of the legacy time-window sync, plus optional `meta.datashare.partitioning` to partition the share on a raw date/timestamp column.

CDF is watermark-driven, so the CDF branch omits `time_column`, `time_start` and `time_end`, and skips the active-sync probe. That probe can't tell a CDF sync from a legacy one, so it would report no active sync on every incremental run and force a needless re-bootstrap. `full_refresh` is left to its existing explicit sources — `dbt --full-refresh`, a `table` materialization, or the manual operation override — which the platform honours as a full re-bootstrap.

Non-CDF models are unaffected: same branch, same generated arguments. `partitioning` is deliberately still forwarded when `is_cdf` is false, so the procedure rejects the invalid combination rather than dbt silently dropping it.

Validation stays out of the Jinja macro on purpose — the procedure and the platform already enforce the contract, and a third implementation would only drift.

Both entry points are unchanged callers of the shared helper, so the global post-hook and `datashare_trigger_sync_operation` pick this up without a second implementation.

Verified with `dbt deps`, `dbt parse --no-partial-parse`, and `dbt compile`, plus rendering the helper directly through `run-operation` to check all four generated shapes: CDF with and without `partitioning`, non-CDF forwarding `partitioning`, and a legacy model. The macro's runtime path only executes against a real target, so the end-to-end sync behaviour still needs a live check.
