### PR TITLE
feat: add meta.datashare_sync for shares that sync without a time window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this template will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- **DataShare sync**: a `meta.datashare_sync` block syncs a model without defining a time window, with an optional `partitioning` key to partition the share on a raw date/timestamp column. Dune advances the share from the last completed sync, so there are no time keys. Delivery is Snowflake-only, so set `target_type: snowflake`. A model cannot carry both `meta.datashare` and `meta.datashare_sync`. See `docs/dune-datashares.md`.
+- **DataShare sync**: a `meta.datashare_sync` block syncs a model without defining a time window, with an optional `partitioning` key to partition the share on a raw date/timestamp column. Dune advances the share from the last completed sync, so there are no time keys, and it delivers to your registered destination without you naming one. A model cannot carry both `meta.datashare` and `meta.datashare_sync`. Remove one of these shares with `delete_datashare_sync`, as `delete_datashare` removes a `meta.datashare` one. See `docs/dune-datashares.md`.
 
 ### Changed
 - **Renamed "table visibility" to "table privacy"** (breaking): the `set_table_visibility` macro is now `set_table_privacy`, `macros/dune_dbt_overrides/set_table_visibility.sql` is now `set_table_privacy.sql`, and `docs/dune-table-visibility.md` is now `docs/dune-table-privacy.md`. Dune's catalog already uses "visibility" for a separate, admin-only property that controls Data Explorer listing. If you call `set_table_visibility` outside the `dbt_project.yml` post-hook, rename the call. The `meta.dune.public` config and the underlying `dune.public` property are unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this template will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- **DataShare CDF**: `meta.datashare.is_cdf` opts a model into DataShare CDF delivery instead of the legacy time-window sync, with optional `meta.datashare.partitioning` to partition the share on a raw date/timestamp column. CDF is watermark-driven, so the `time_*` keys do not apply. Delivery is Snowflake-only, so set `target_type: snowflake`. See `docs/dune-datashares.md`.
+- **DataShare sync**: a `meta.datashare_sync` block syncs a model without defining a time window, with an optional `partitioning` key to partition the share on a raw date/timestamp column. Dune advances the share from the last completed sync, so there are no time keys. Delivery is Snowflake-only, so set `target_type: snowflake`. A model cannot carry both `meta.datashare` and `meta.datashare_sync`. See `docs/dune-datashares.md`.
 
 ### Fixed
 - **Datashare `run-operation` could sync dev schemas**: `datashare_trigger_sync_operation` had no target guard, so running it without `--target prod` registered the dev temp schema (`<team>__tmp_<suffix>`) as a real datashare and shipped it to the destination warehouse. It now raises a clear error outside `prod`, naming the schema it would have registered. `dry_run: true` is still permitted on any target, and `allow_prod_only: false` is available as an explicit override.

--- a/docs/dune-datashares.md
+++ b/docs/dune-datashares.md
@@ -21,8 +21,9 @@ This template ships with datashare support already wired in:
 - `macros/dune_dbt_overrides/datashare_table_sync_post_hook.sql`
 - a global post-hook in `dbt_project.yml` that calls `datashare_trigger_sync()`
 - an opt-in example model at `models/templates/dbt_template_datashare_incremental_model.sql`
+- a DataShare sync example model at `models/templates/dbt_template_datashare_sync_model.sql`
 
-Models without `meta.datashare` are unchanged. The hook skips them.
+Models without `meta.datashare` or `meta.datashare_sync` are unchanged. The hook skips them.
 
 The built-in post-hook only executes on the `prod` target, so local `dev` runs and CI temp schemas do not create datashare syncs by default.
 
@@ -75,30 +76,35 @@ The post-hook macro evaluates `is_incremental()` at execution time and picks the
 
 ## Configuration Reference
 
-All datashare config lives under `meta.datashare` in the model `config()` block.
+Time-window config lives under `meta.datashare` in the model `config()` block. Models that sync without a time window use `meta.datashare_sync` instead.
 
 | Property                 | Required | Type           | Description                                                                 |
 | ------------------------ | -------- | -------------- | --------------------------------------------------------------------------- |
 | `enabled`                | Yes      | `boolean`      | Must be `true` to trigger sync.                                             |
-| `time_column`            | Yes\*    | `string`       | Column used to define the sync window. Not used when `is_cdf` is `true`.    |
-| `time_start`             | Yes\*    | `string`       | SQL expression for the start of the full-refresh sync window.               |
+| `time_column`            | Yes      | `string`       | Column used to define the sync window.                                     |
+| `time_start`             | Yes      | `string`       | SQL expression for the start of the full-refresh sync window.               |
 | `time_start_incremental` | No       | `string`       | SQL expression for incremental runs. Falls back to `time_start` if omitted. |
 | `time_end`               | No       | `string`       | SQL expression for the end of the sync window. Defaults to `now()`.         |
 | `unique_key_columns`     | No       | `list[string]` | Row identity columns. Falls back to the model `unique_key` if omitted.      |
-| `is_cdf`                 | No       | `boolean`      | Opt into DataShare CDF delivery. Defaults to `false` (legacy path).         |
-| `partitioning`           | No       | `string`       | Raw, untransformed date/timestamp source column to partition the CDF share on. |
-
-\* Required for the legacy time-window path only. Omit them for `is_cdf: true` models.
 
 All time expressions are SQL, not literal timestamps. The macro wraps them in `CAST(... AS VARCHAR)` before calling the table procedure.
 
 Keep the sync window aligned with the `time_column` granularity. For example, if `time_column` is a `date`, use date-based expressions like `current_date - interval '1' day`, not hour-based timestamp windows.
 
-### DataShare CDF
+### DataShare sync
 
-Set `meta.datashare.is_cdf: true` to route a model through the DataShare CDF contract instead of the legacy time-window sync. CDF is watermark-driven, so the time keys do not apply — delete them.
+Add a `meta.datashare_sync` block instead of `meta.datashare` to sync a model without defining a time window. A model cannot carry both blocks — dbt fails compilation naming both keys, telling you to keep exactly one.
 
-Also set `target_type: snowflake`. CDF delivers to Snowflake only, and omitting the target is accepted by dbt but rejected once the statement reaches Trino.
+Dune advances the share from the last completed sync, so there are no time keys.
+
+| Property         | Required | Type      | Description                                                                     |
+| ---------------- | -------- | --------- | -------------------------------------------------------------------------------- |
+| `enabled`        | Yes      | `boolean` | Must be `true` to trigger sync.                                                 |
+| `partitioning`   | No       | `string`  | Raw, untransformed date/timestamp source column to partition the share on. |
+
+`unique_key_columns` comes from the model-level `unique_key` config.
+
+Dune delivers to the target your team has registered, so there are no target keys either. This kind of share is delivered to Snowflake only.
 
 ```sql
 {{ config(
@@ -106,11 +112,9 @@ Also set `target_type: snowflake`. CDF delivers to Snowflake only, and omitting 
     , incremental_strategy = 'merge'
     , unique_key = ['block_number', 'block_date']
     , meta = {
-        "datashare": {
+        "datashare_sync": {
             "enabled": true,
-            "is_cdf": true,
-            "partitioning": "block_date",
-            "target_type": "snowflake"
+            "partitioning": "block_date"
         }
     }
 ) }}
@@ -119,8 +123,6 @@ select ...
 ```
 
 `full_refresh` re-bootstraps the destination: it is re-copied in full from the current source snapshot instead of advancing from the last watermark. Changing `partitioning` on an existing sync requires it, and is rejected while a bootstrap is in flight.
-
-Setting `partitioning` without `is_cdf: true` is rejected by Trino, not by dbt.
 
 ## Cadence and sync windows
 
@@ -182,7 +184,7 @@ The macro determines `full_refresh` automatically:
 | Table materialization post-hook                        | `true`                    |
 | `run-operation`                                        | `false` unless overridden |
 
-For `is_cdf: true` models this table is the only source of `full_refresh`; there is no active-sync probe.
+For `meta.datashare_sync` models this table is the only source of `full_refresh`; there is no active-sync probe.
 
 ## Generated SQL
 
@@ -198,19 +200,19 @@ ALTER TABLE dune.<schema>.<table> EXECUTE datashare(
 )
 ```
 
-With `is_cdf: true`, the time-window properties are dropped:
+`target_type` / `target_region` are appended only when configured.
+
+A `meta.datashare_sync` model calls a different procedure, with no time-window properties:
 
 ```sql
-ALTER TABLE dune.<schema>.<table> EXECUTE datashare(
-    is_cdf => true,
+ALTER TABLE dune.<schema>.<table> EXECUTE sync_datashare(
     unique_key_columns => ARRAY['col1', 'col2'],
     full_refresh => true|false,
-    target_type => 'snowflake',
     partitioning => '<column_name>'
 )
 ```
 
-`target_type` / `target_region` / `partitioning` are appended in both modes only when configured.
+`partitioning` is appended only when configured.
 
 ## Manual Syncs
 

--- a/docs/dune-datashares.md
+++ b/docs/dune-datashares.md
@@ -104,7 +104,7 @@ Dune advances the share from the last completed sync, so there are no time keys.
 
 `unique_key_columns` comes from the model-level `unique_key` config.
 
-Dune delivers to the target your team has registered, so there are no target keys either. This kind of share is delivered to Snowflake only.
+Dune delivers to the target your team has registered, so there are no target keys either.
 
 ```sql
 {{ config(

--- a/docs/dune-datashares.md
+++ b/docs/dune-datashares.md
@@ -102,7 +102,7 @@ Dune advances the share from the last completed sync, so there are no time keys.
 | `enabled`        | Yes      | `boolean` | Must be `true` to trigger sync.                                                 |
 | `partitioning`   | No       | `string`  | Raw, untransformed date/timestamp source column to partition the share on. |
 
-`unique_key_columns` comes from the model-level `unique_key` config.
+`unique_key_columns` comes from the model-level `unique_key` config, which must be set and non-empty.
 
 Dune delivers to the target your team has registered, so there are no target keys either.
 

--- a/docs/dune-datashares.md
+++ b/docs/dune-datashares.md
@@ -275,13 +275,19 @@ ORDER BY created_at DESC;
 
 ## Cleanup
 
-Remove a table from datashare with:
+Remove a `meta.datashare` table from datashare with:
 
 ```sql
 ALTER TABLE dune.<schema>.<table> EXECUTE delete_datashare
 ```
 
-This stops the sync and revokes access to the destination.
+A `meta.datashare_sync` table uses the matching procedure:
+
+```sql
+ALTER TABLE dune.<schema>.<table> EXECUTE delete_datashare_sync
+```
+
+Either one stops the sync and revokes access to the destination.
 
 ## S3 Export
 

--- a/macros/dune_dbt_overrides/datashare_table_sync_post_hook.sql
+++ b/macros/dune_dbt_overrides/datashare_table_sync_post_hook.sql
@@ -92,6 +92,28 @@
     {%- endif -%}
 
     {%- if has_sync -%}
+        {#- Reject anything this block does not act on, so a misspelled key fails
+            loudly instead of silently syncing a different shape than asked for. -#}
+        {%- set supported_sync_keys = ['enabled', 'partitioning'] -%}
+        {%- set unsupported_keys = [] -%}
+        {%- for key in datashare_sync.keys() -%}
+            {%- if key not in supported_sync_keys -%}
+                {%- do unsupported_keys.append(key) -%}
+            {%- endif -%}
+        {%- endfor -%}
+        {%- if unsupported_keys | length > 0 -%}
+            {{ exceptions.raise_compiler_error(
+                "Model " ~ model_ref ~ " has unsupported meta.datashare_sync keys: "
+                ~ (unsupported_keys | sort | join(', '))
+                ~ ". Supported keys: " ~ (supported_sync_keys | join(', ')) ~ "."
+            ) }}
+        {%- endif -%}
+        {%- if time_start is not none or time_end is not none -%}
+            {{ exceptions.raise_compiler_error(
+                "Model " ~ model_ref ~ " uses meta.datashare_sync, which syncs without a time window."
+                ~ " Drop time_start/time_end."
+            ) }}
+        {%- endif -%}
         {%- if datashare_sync.get('enabled') is not sameas true -%}
             {{ log('Skipping datashare sync for ' ~ model_ref ~ ': meta.datashare_sync.enabled is not true.', info=True) }}
             {{ return(none) }}

--- a/macros/dune_dbt_overrides/datashare_table_sync_post_hook.sql
+++ b/macros/dune_dbt_overrides/datashare_table_sync_post_hook.sql
@@ -53,8 +53,8 @@
 {%- endmacro -%}
 
 {#
-    Datashare sync macro - generates ALTER TABLE ... EXECUTE datashare() SQL.
-    Config reference and usage: docs/dune-datashares.md
+    Datashare sync macro - generates ALTER TABLE ... EXECUTE datashare()/sync_datashare()
+    SQL depending on which meta block is configured. Config reference: docs/dune-datashares.md
 #}
 {% macro _datashare_table_sync_sql(
     schema_name
@@ -68,22 +68,54 @@
     , catalog_name=target.database
 ) %}
     {%- set model_ref = schema_name ~ '.' ~ table_name -%}
-    {%- if meta is not mapping or meta.get('datashare') is none or meta.get('datashare') is not mapping -%}
-        {{ log('Skipping datashare sync for ' ~ model_ref ~ ': meta.datashare is not configured.', info=True) }}
+    {%- set legacy_datashare = meta.get('datashare') if meta is mapping else none -%}
+    {%- set datashare_sync = meta.get('datashare_sync') if meta is mapping else none -%}
+    {%- set has_legacy = legacy_datashare is mapping -%}
+    {%- set has_sync = datashare_sync is mapping -%}
+
+    {%- if has_legacy and has_sync -%}
+        {{ exceptions.raise_compiler_error(
+            "Model " ~ model_ref ~ " has both meta.datashare and meta.datashare_sync configured."
+            ~ " Keep exactly one: meta.datashare to sync a time window,"
+            ~ " meta.datashare_sync to sync without one."
+        ) }}
+    {%- endif -%}
+
+    {%- if not has_legacy and not has_sync -%}
+        {{ log('Skipping datashare sync for ' ~ model_ref ~ ': neither meta.datashare nor meta.datashare_sync is configured.', info=True) }}
         {{ return(none) }}
     {%- endif -%}
-    {%- set datashare = meta.get('datashare') -%}
-    {%- if datashare.get('enabled') is not sameas true -%}
-        {{ log('Skipping datashare sync for ' ~ model_ref ~ ': meta.datashare.enabled is not true.', info=True) }}
-        {{ return(none) }}
-    {%- endif -%}
+
     {%- if materialized not in ['incremental', 'table'] -%}
         {{ log('Skipping datashare sync for ' ~ model_ref ~ ': materialization "' ~ materialized ~ '" is not incremental/table.') }}
         {{ return(none) }}
     {%- endif -%}
-    {%- set is_cdf = datashare.get('is_cdf') is sameas true -%}
-    {%- set partitioning = datashare.get('partitioning') -%}
-    {%- set include_partitioning = partitioning is not none and partitioning | string | trim != '' -%}
+
+    {%- if has_sync -%}
+        {%- if datashare_sync.get('enabled') is not sameas true -%}
+            {{ log('Skipping datashare sync for ' ~ model_ref ~ ': meta.datashare_sync.enabled is not true.', info=True) }}
+            {{ return(none) }}
+        {%- endif -%}
+        {%- set partitioning = datashare_sync.get('partitioning') -%}
+        {%- set include_partitioning = partitioning is not none and partitioning | string | trim != '' -%}
+        {%- set sql -%}
+ALTER TABLE {{ catalog_name }}.{{ schema_name }}.{{ table_name }} EXECUTE sync_datashare(
+    unique_key_columns => {{ _datashare_unique_key_columns_sql(unique_key) }},
+    full_refresh => {{ 'true' if full_refresh else 'false' }}
+{%- if include_partitioning -%}
+    , partitioning => {{ _datashare_sql_string(partitioning) }}
+{%- endif -%}
+)
+        {%- endset -%}
+        {{ log('datashare sync preview for ' ~ model_ref ~ ':\n' ~ sql, info=True) }}
+        {{ return(sql) }}
+    {%- endif -%}
+
+    {%- set datashare = legacy_datashare -%}
+    {%- if datashare.get('enabled') is not sameas true -%}
+        {{ log('Skipping datashare sync for ' ~ model_ref ~ ': meta.datashare.enabled is not true.', info=True) }}
+        {{ return(none) }}
+    {%- endif -%}
     {%- set time_column = datashare.get('time_column') -%}
     {%- set resolved_time_start = time_start if time_start is not none else datashare.get('time_start') -%}
     {%- set resolved_time_end = time_end if time_end is not none else datashare.get('time_end', 'now()') -%}
@@ -95,36 +127,24 @@
     {#- An incremental sync targets an existing destination via MERGE. If the
         destination sync was revoked while the source table still exists, dbt
         builds incrementally but there is nothing to merge into. Force a full
-        refresh when no active sync is registered for this table/target.
-        CDF bootstrap classification happens on the Dune side instead: skip the
-        probe so an explicit CDF request is not forced through a spurious
-        re-bootstrap. -#}
-    {%- if not is_cdf and not full_refresh and not _datashare_active_sync_exists(schema_name, table_name, target_type, target_region) -%}
+        refresh when no active sync is registered for this table/target. -#}
+    {%- if not full_refresh and not _datashare_active_sync_exists(schema_name, table_name, target_type, target_region) -%}
         {{ log('No active datashare sync for ' ~ model_ref ~ '; forcing full_refresh.', info=True) }}
         {%- set full_refresh = true -%}
     {%- endif -%}
 
     {%- set sql -%}
 ALTER TABLE {{ catalog_name }}.{{ schema_name }}.{{ table_name }} EXECUTE datashare(
-{%- if is_cdf -%}
-    is_cdf => true,
-    unique_key_columns => {{ _datashare_unique_key_columns_sql(datashare.get('unique_key_columns', unique_key)) }},
-    full_refresh => {{ 'true' if full_refresh else 'false' }}
-{%- else -%}
     time_column => {{ _datashare_sql_string(time_column | default('', true)) }},
     unique_key_columns => {{ _datashare_unique_key_columns_sql(datashare.get('unique_key_columns', unique_key)) }},
     time_start => {{ _datashare_optional_time_sql(resolved_time_start) }},
     time_end => {{ _datashare_optional_time_sql(resolved_time_end) }},
     full_refresh => {{ 'true' if full_refresh else 'false' }}
-{%- endif -%}
 {%- if include_target_type -%}
     , target_type => {{ _datashare_sql_string(target_type) }}
 {%- endif -%}
 {%- if include_target_region -%}
     , target_region => {{ _datashare_sql_string(target_region) }}
-{%- endif -%}
-{%- if include_partitioning -%}
-    , partitioning => {{ _datashare_sql_string(partitioning) }}
 {%- endif -%}
 )
     {%- endset -%}
@@ -226,7 +246,7 @@ ALTER TABLE {{ catalog_name }}.{{ schema_name }}.{{ table_name }} EXECUTE datash
     ) -%}
 
     {%- if sql is none -%}
-        {{ exceptions.raise_compiler_error("Cannot sync " ~ node.schema ~ "." ~ table_name ~ ": model must be incremental or table with meta.datashare.enabled = true.") }}
+        {{ exceptions.raise_compiler_error("Cannot sync " ~ node.schema ~ "." ~ table_name ~ ": model must be incremental or table with meta.datashare.enabled or meta.datashare_sync.enabled set to true.") }}
     {%- endif -%}
 
     {%- if not is_dry_run -%}

--- a/models/templates/dbt_template_datashare_incremental_model.sql
+++ b/models/templates/dbt_template_datashare_incremental_model.sql
@@ -9,16 +9,8 @@
 -- full day from the destination (24x amplification on cross-region S3 buckets).
 -- For hourly freshness, see the "Hourly cadence" example in the docs.
 --
--- To opt this model into DataShare CDF instead (see the "DataShare CDF"
--- section of docs/dune-datashares.md), replace the time keys in meta.datashare
--- below with:
---   "is_cdf": true,
---   "partitioning": "block_date",
---   "target_type": "snowflake"
---
--- CDF is watermark-driven, so `time_column`, `time_start`,
--- `time_start_incremental` and `time_end` are unused under `is_cdf` -- delete
--- them from meta.datashare.
+-- For a datashare that syncs without a time window, see
+-- dbt_template_datashare_sync_model.sql.
 {%- set time_start_incremental = "current_date - interval '1' day" -%}
 {%- set time_start = "current_date - interval '2' day" -%}
 {%- set time_end = "current_date + interval '1' day" -%}

--- a/models/templates/dbt_template_datashare_sync_model.sql
+++ b/models/templates/dbt_template_datashare_sync_model.sql
@@ -1,0 +1,41 @@
+-- DataShare sync example (see docs/dune-datashares.md "DataShare sync").
+--
+-- Dune advances this share from the last completed sync, so there is no time
+-- window to configure and `meta.datashare_sync` carries no time keys.
+--
+-- Dune delivers the share to the target your team has registered. This kind of
+-- share is delivered to Snowflake only.
+--
+-- A model cannot carry both `meta.datashare` and `meta.datashare_sync`.
+{%- set time_start_incremental = "current_date - interval '1' day" -%}
+{%- set time_start = "current_date - interval '2' day" -%}
+{%- set time_end = "current_date + interval '1' day" -%}
+
+{{ config(
+    alias = 'dbt_template_datashare_sync_model'
+    , materialized = 'incremental'
+    , incremental_strategy = 'merge'
+    , unique_key = ['block_number', 'block_date']
+    , incremental_predicates = ["DBT_INTERNAL_DEST.block_date >= " ~ time_start_incremental]
+    , meta = {
+        "dune": {
+            "public": false
+        },
+        "datashare_sync": {
+            "enabled": true,
+            "partitioning": "block_date"
+        }
+    }
+    , properties = {
+        "partitioned_by": "ARRAY['block_date']"
+    }
+) }}
+
+select
+    block_number
+    , block_date
+    , count(*) as total_tx_per_block
+from {{ source('ethereum', 'transactions') }}
+where block_date >= {{ time_start_incremental if is_incremental() else time_start }}
+  and block_date < {{ time_end }}
+group by 1, 2


### PR DESCRIPTION
## What & why

Some DataShares do not have a time window to replay. Dune advances those from the
last completed sync, so `time_column` / `time_start` / `time_end` are meaningless
for them and the existing `meta.datashare` block cannot describe one.

This adds a second config block, `meta.datashare_sync`. A model carrying it is
routed to `sync_datashare(...)`; a model carrying `meta.datashare` keeps emitting
`datashare(...)` exactly as before. Carrying both raises a compiler error rather
than silently picking one.

Delivery for the new block is Snowflake-only, so `target_type: snowflake` is
required on those models.

`models/templates/dbt_template_datashare_sync_model.sql` is a new worked example
alongside the existing time-window one, and `docs/dune-datashares.md` gains a
`DataShare sync` section with its own config reference.

## Verification

This repo runs no dbt CI, so verification was local:

- `dbt parse --no-partial-parse` clean.
- Both example models compile with no errors.
- The post-hook was rendered directly for every branch — `meta.datashare_sync`
  with and without the optional keys, `enabled: false`, a `meta.datashare` model
  (byte-identical to the previous output), and a model carrying both blocks.
